### PR TITLE
EnumCodec's canDecode method fix (Issue #302)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ hs_err_pid*
 .classpath
 .project
 .settings
+/bin/

--- a/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.extension.CodecRegistrar;
 import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.core.publisher.Mono;
@@ -63,7 +64,8 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
     @Override
     public boolean canDecode(int dataType, Format format, Class<?> type) {
         Assert.requireNonNull(type, "type must not be null");
-        return this.type.equals(type) && dataType == this.oid;
+        
+        return type.isAssignableFrom(this.type) && dataType == this.oid;
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.extension.CodecRegistrar;
 import io.r2dbc.postgresql.message.Format;
-import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.core.publisher.Mono;
@@ -64,7 +63,6 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
     @Override
     public boolean canDecode(int dataType, Format format, Class<?> type) {
         Assert.requireNonNull(type, "type must not be null");
-        
         return type.isAssignableFrom(this.type) && dataType == this.oid;
     }
 

--- a/src/test/java/io/r2dbc/postgresql/codec/EnumCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/EnumCodecUnitTests.java
@@ -15,24 +15,20 @@
  */
 
 package io.r2dbc.postgresql.codec;
+import io.r2dbc.postgresql.message.Format;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSON;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSONB;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
-import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import java.util.Map;
+import io.netty.buffer.UnpooledByteBufAllocator;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import io.netty.buffer.AbstractByteBufAllocator;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.r2dbc.postgresql.message.Format;
 
 /**
  * Unit tests for {@link EnumCodec}.
@@ -41,7 +37,6 @@ final class EnumCodecUnitTests {
 
     @Test
     void shouldRejectMultipleMappingForJavaType() {
-
         EnumCodec.Builder builder = EnumCodec.builder().withEnum("foo", MyEnum.class);
 
         Assertions.assertThatIllegalArgumentException().isThrownBy(() -> builder.withEnum("bar", MyEnum.class));
@@ -49,7 +44,6 @@ final class EnumCodecUnitTests {
 
     @Test
     void shouldRejectMultipleMappingForTypeName() {
-
         EnumCodec.Builder builder = EnumCodec.builder().withEnum("foo", MyEnum.class);
 
         Assertions.assertThatIllegalArgumentException().isThrownBy(() -> builder.withEnum("foo", MyOtherEnum.class));
@@ -62,9 +56,10 @@ final class EnumCodecUnitTests {
 		
 		assertThat(codec.canDecode(1, Format.FORMAT_TEXT, MyEnum.class)).isTrue();
 		assertThat(codec.canDecode(1, FORMAT_BINARY, MyEnum.class)).isTrue();
+		assertThat(codec.canDecode(1, FORMAT_BINARY, Object.class)).isTrue();
 		assertThat(codec.canDecode(VARCHAR.getObjectId(), FORMAT_BINARY, MyEnum.class)).isFalse();
-        assertThat(codec.canDecode(JSON.getObjectId(), FORMAT_TEXT, MyEnum.class)).isFalse();
-        assertThat(codec.canDecode(JSONB.getObjectId(), FORMAT_BINARY, MyEnum.class)).isFalse();
+		assertThat(codec.canDecode(JSON.getObjectId(), FORMAT_TEXT, MyEnum.class)).isFalse();
+		assertThat(codec.canDecode(JSONB.getObjectId(), FORMAT_BINARY, MyEnum.class)).isFalse();
     }
     
     @Test
@@ -74,7 +69,6 @@ final class EnumCodecUnitTests {
             .withMessage("type must not be null");
     }
 
-    
     enum MyEnum {
         INSTANCE;
     }


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
Retrieving a column value throughRow.get("my_enum_column") fails for EnumCodec. Row.get(identifier) is a default method that forwards to Row.get(identifier, Object.class). EnumCodec checks whether the requested type that it should decode with Object.class.equals(theEnumType).
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
