### PR TITLE
Add priority to EnumCodec registrar

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
@@ -119,7 +119,7 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
      */
     public static final class Builder {
 
-        private final Map<String, Class<? extends Enum<?>>> mapping = new LinkedHashMap<>();
+        private final Map<String, EnumMappingConfig> mapping = new LinkedHashMap<>();
 
         /**
          * Add a Postgres enum type to {@link Enum} mapping.
@@ -129,6 +129,19 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
          * @return this {@link Builder}
          */
         public Builder withEnum(String name, Class<? extends Enum<?>> enumClass) {
+            return withEnum(name, enumClass, RegistrationPriority.LAST);
+        }
+
+        /**
+         * Add a Postgres enum type to {@link Enum} mapping.
+         *
+         * @param name      name of the Postgres enum type
+         * @param enumClass the corresponding Java type
+         * @param priority  the codec registration priority
+         * @return this {@link Builder}
+         */
+        public Builder withEnum(String name, Class<? extends Enum<?>> enumClass, RegistrationPriority priority) {
+            Assert.requireNotEmpty(name, "Postgres type name must not be null");
             Assert.requireNonNull(enumClass, "Enum class must not be null");
             Assert.isTrue(enumClass.isEnum(), String.format("Enum class %s must be an enum type", enumClass.getName()));
 
@@ -136,11 +149,11 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
                 throw new IllegalArgumentException(String.format("Builder contains already a mapping for Postgres type %s", name));
             }
 
-            if (this.mapping.containsValue(enumClass)) {
+            if (this.mapping.values().stream().anyMatch(config -> config.enumClass.equals(enumClass))) {
                 throw new IllegalArgumentException(String.format("Builder contains already a mapping for Java type %s", enumClass.getName()));
             }
 
-            this.mapping.put(Assert.requireNotEmpty(name, "Postgres type name must not be null"), enumClass);
+            this.mapping.put(name, new EnumMappingConfig(enumClass, priority));
             return this;
         }
 
@@ -153,7 +166,7 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
         @SuppressWarnings({"unchecked", "rawtypes"})
         public CodecRegistrar build() {
 
-            Map<String, Class<? extends Enum<?>>> mapping = new LinkedHashMap<>(this.mapping);
+            Map<String, EnumMappingConfig> mapping = new LinkedHashMap<>(this.mapping);
 
             return (connection, allocator, registry) -> {
 
@@ -162,15 +175,19 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
                     .filter(PostgresTypes.PostgresType::isEnum)
                     .doOnNext(it -> {
 
-                        Class<? extends Enum<?>> enumClass = mapping.get(it.getName());
-                        if (enumClass == null) {
+                        EnumMappingConfig mappingConfig = mapping.get(it.getName());
+                        if (mappingConfig == null) {
                             logger.warn(String.format("Cannot find Java type for enum type '%s' with oid %d. Known types are: %s", it.getName(), it.getOid(), mapping));
                             return;
                         }
 
                         missing.remove(it.getName());
-                        logger.debug(String.format("Registering codec for type '%s' with oid %d using Java enum type '%s'", it.getName(), it.getOid(), enumClass.getName()));
-                        registry.addLast(new EnumCodec(allocator, enumClass, it.getOid()));
+                        logger.debug(String.format("Registering codec for type '%s' with oid %d using Java enum type '%s'", it.getName(), it.getOid(), mappingConfig.getClass().getName()));
+                        if (mappingConfig.registrationPriority == RegistrationPriority.LAST) {
+                            registry.addLast(new EnumCodec(allocator, mappingConfig.getClass(), it.getOid()));
+                        } else {
+                            registry.addFirst(new EnumCodec(allocator, mappingConfig.getClass(), it.getOid()));
+                        }
                     }).doOnComplete(() -> {
 
                         if (!missing.isEmpty()) {
@@ -179,6 +196,27 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
 
                     }).then();
             };
+        }
+
+        /**
+         * An enumeration of codec registration priorities.
+         */
+        public enum RegistrationPriority {
+            FIRST,
+            LAST
+        }
+
+        private static final class EnumMappingConfig {
+
+            private final Class<? extends Enum<?>> enumClass;
+
+            private final RegistrationPriority registrationPriority;
+
+            EnumMappingConfig(Class<? extends Enum<?>> enumClass, RegistrationPriority registrationPriority) {
+                this.enumClass = enumClass;
+                this.registrationPriority = registrationPriority;
+            }
+
         }
 
     }

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlConnection.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlConnection.java
@@ -1,0 +1,101 @@
+package io.r2dbc.postgresql.api;
+
+import io.r2dbc.spi.IsolationLevel;
+import io.r2dbc.spi.ValidationDepth;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class MockPostgresqlConnection implements PostgresqlConnection {
+
+    private final MockPostgresqlStatement statement;
+
+    public MockPostgresqlConnection(MockPostgresqlStatement statement) {
+        this.statement = statement;
+    }
+
+    @Override
+    public Mono<Void> beginTransaction() {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> close() {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> commitTransaction() {
+        return Mono.empty();
+    }
+
+    @Override
+    public PostgresqlBatch createBatch() {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> createSavepoint(String name) {
+        return Mono.empty();
+    }
+
+    @Override
+    public PostgresqlStatement createStatement(String sql) {
+        return this.statement;
+    }
+
+    @Override
+    public Flux<Notification> getNotifications() {
+        return Flux.empty();
+    }
+
+    @Override
+    public Mono<Void> cancelRequest() {
+        return Mono.empty();
+    }
+
+    @Override
+    public PostgresqlConnectionMetadata getMetadata() {
+        return null;
+    }
+
+    @Override
+    public IsolationLevel getTransactionIsolationLevel() {
+        return null;
+    }
+
+    @Override
+    public boolean isAutoCommit() {
+        return false;
+    }
+
+    @Override
+    public Mono<Void> releaseSavepoint(String name) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> rollbackTransaction() {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> rollbackTransactionToSavepoint(String name) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> setAutoCommit(boolean autoCommit) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Boolean> validate(ValidationDepth depth) {
+        return Mono.empty();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlConnection.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.r2dbc.postgresql.api;
 
 import io.r2dbc.spi.IsolationLevel;

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlResult.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.r2dbc.postgresql.api;
 
 import io.r2dbc.spi.Row;

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlResult.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlResult.java
@@ -1,0 +1,69 @@
+package io.r2dbc.postgresql.api;
+
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public class MockPostgresqlResult implements PostgresqlResult {
+
+    private final Mono<RowMetadata> rowMetadata;
+
+    private final Flux<Row> rows;
+
+    public MockPostgresqlResult(Mono<RowMetadata> rowMetadata, Flux<Row> rows) {
+        this.rowMetadata = rowMetadata;
+        this.rows = rows;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Mono<Integer> getRowsUpdated() {
+        return Mono.empty();
+    }
+
+    @Override
+    public <T> Flux<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction) {
+        return this.rows
+            .zipWith(this.rowMetadata.repeat())
+            .map((tuple) -> {
+                Row row = tuple.getT1();
+                RowMetadata rowMetadata = tuple.getT2();
+
+                return mappingFunction.apply(row, rowMetadata);
+            });
+    }
+
+    public static final class Builder {
+
+        private final List<Row> rows = new ArrayList<>();
+
+        private RowMetadata rowMetadata;
+
+        private Builder() {
+        }
+
+        public MockPostgresqlResult build() {
+            return new MockPostgresqlResult(Mono.justOrEmpty(this.rowMetadata), Flux.fromIterable(this.rows));
+        }
+
+        public Builder rowMetadata(RowMetadata rowMetadata) {
+            this.rowMetadata = rowMetadata;
+            return this;
+        }
+
+        public Builder row(Row row) {
+            this.rows.add(row);
+            return this;
+        }
+
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlStatement.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlStatement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.r2dbc.postgresql.api;
 
 import reactor.core.publisher.Flux;

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlStatement.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlStatement.java
@@ -1,0 +1,73 @@
+package io.r2dbc.postgresql.api;
+
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockPostgresqlStatement implements PostgresqlStatement {
+
+    private final Flux<PostgresqlResult> results;
+
+    public MockPostgresqlStatement(Flux<PostgresqlResult> results) {
+        this.results = results;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public PostgresqlStatement add() {
+        return this;
+    }
+
+    @Override
+    public PostgresqlStatement bind(String identifier, Object value) {
+        return this;
+    }
+
+    @Override
+    public PostgresqlStatement bind(int index, Object value) {
+        return this;
+    }
+
+    @Override
+    public PostgresqlStatement bindNull(String identifier, Class<?> type) {
+        return this;
+    }
+
+    @Override
+    public PostgresqlStatement bindNull(int index, Class<?> type) {
+        return this;
+    }
+
+    @Override
+    public Flux<PostgresqlResult> execute() {
+        return this.results;
+    }
+
+    @Override
+    public PostgresqlStatement returnGeneratedValues(String... columns) {
+        return this;
+    }
+
+    public static final class Builder {
+
+        private final List<PostgresqlResult> results = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public MockPostgresqlStatement build() {
+            return new MockPostgresqlStatement(Flux.fromIterable(this.results));
+        }
+
+        public Builder result(PostgresqlResult result) {
+            this.results.add(result);
+            return this;
+        }
+
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/EnumCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/EnumCodecUnitTests.java
@@ -25,11 +25,16 @@ import io.r2dbc.spi.test.MockRow;
 import io.r2dbc.spi.test.MockRowMetadata;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import reactor.test.StepVerifier;
 
 import static io.r2dbc.postgresql.codec.EnumCodec.Builder.RegistrationPriority;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link EnumCodec}.
@@ -56,11 +61,12 @@ final class EnumCodecUnitTests {
     void shouldRegisterCodecAsFirst() {
         CodecRegistrar codecRegistrar = EnumCodec
             .builder()
-            .withEnum("foo", MyEnum.class, RegistrationPriority.FIRST)
+            .withRegistrationPriority(RegistrationPriority.FIRST)
+            .withEnum("foo", MyEnum.class)
             .build();
 
-        ByteBufAllocator mockByteBufAllocator = Mockito.mock(ByteBufAllocator.class);
-        CodecRegistry mockCodecRegistry = Mockito.mock(CodecRegistry.class);
+        ByteBufAllocator mockByteBufAllocator = mock(ByteBufAllocator.class);
+        CodecRegistry mockCodecRegistry = mock(CodecRegistry.class);
 
         MockPostgresqlStatement mockPostgresqlStatement = MockPostgresqlStatement.builder()
             .result(MockPostgresqlResult.builder()
@@ -77,20 +83,21 @@ final class EnumCodecUnitTests {
         Publisher<Void> register = codecRegistrar.register(mockPostgresqlConnection, mockByteBufAllocator, mockCodecRegistry);
         StepVerifier.create(register).verifyComplete();
 
-        Mockito.verify(mockCodecRegistry, Mockito.only()).addFirst(Mockito.any(EnumCodec.class));
-        Mockito.verify(mockCodecRegistry, Mockito.never()).addLast(Mockito.any(EnumCodec.class));
+        verify(mockCodecRegistry, only()).addFirst(any(EnumCodec.class));
+        verify(mockCodecRegistry, never()).addLast(any(EnumCodec.class));
     }
 
     @Test
     void shouldRegisterCodecAsLast() {
         CodecRegistrar codecRegistrar = EnumCodec
             .builder()
-            .withEnum("foo", MyEnum.class, RegistrationPriority.LAST)
+            .withRegistrationPriority(RegistrationPriority.LAST)
+            .withEnum("foo", MyEnum.class)
             .withEnum("bar", MyOtherEnum.class)
             .build();
 
-        ByteBufAllocator mockByteBufAllocator = Mockito.mock(ByteBufAllocator.class);
-        CodecRegistry mockCodecRegistry = Mockito.mock(CodecRegistry.class);
+        ByteBufAllocator mockByteBufAllocator = mock(ByteBufAllocator.class);
+        CodecRegistry mockCodecRegistry = mock(CodecRegistry.class);
 
         MockPostgresqlStatement mockPostgresqlStatement = MockPostgresqlStatement.builder()
             .result(MockPostgresqlResult.builder()
@@ -112,8 +119,8 @@ final class EnumCodecUnitTests {
         Publisher<Void> register = codecRegistrar.register(mockPostgresqlConnection, mockByteBufAllocator, mockCodecRegistry);
         StepVerifier.create(register).verifyComplete();
 
-        Mockito.verify(mockCodecRegistry, Mockito.never()).addFirst(Mockito.any(EnumCodec.class));
-        Mockito.verify(mockCodecRegistry, Mockito.times(2)).addLast(Mockito.any(EnumCodec.class));
+        verify(mockCodecRegistry, never()).addFirst(any(EnumCodec.class));
+        verify(mockCodecRegistry, times(2)).addLast(any(EnumCodec.class));
     }
 
     enum MyEnum {


### PR DESCRIPTION
#### Issue description

Resolves #303 
 
#### New Public APIs

- `EnumCodec.Builder#withEnum(String, Class<? extends Enum<?>>, RegistrationPriority)`
- enum `EnumCodec.Builder.RegistrationPriority`. Maybe it make sense to move this inner enum to upper level.

#### Additional context

- Added `MockPostgresqlConnection`, `MockPostgresqlResult` and `MockPostgresqlStatement` for tests. These classes are partially implemented, but this is sufficient for test cases in the PR.
