### PR TITLE
#301 Fix IllegalArgumentException issue in TemporalCodec.canDecode on custom type object

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
@@ -61,7 +61,7 @@ abstract class AbstractNumericCodec<T extends Number> extends AbstractCodec<T> {
         Assert.requireNonNull(type, "type must not be null");
 
         if (type == Object.class) {
-            if (PostgresqlObjectId.valueOf(dataType) != getDefaultType()) {
+            if (PostgresqlObjectId.isValid(dataType) && PostgresqlObjectId.valueOf(dataType) != getDefaultType()) {
                 return false;
             }
         }

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractTemporalCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractTemporalCodec.java
@@ -66,7 +66,7 @@ abstract class AbstractTemporalCodec<T extends Temporal> extends AbstractCodec<T
         Assert.requireNonNull(type, "type must not be null");
 
         if (type == Object.class) {
-            if (PostgresqlObjectId.valueOf(dataType) != getDefaultType()) {
+            if (PostgresqlObjectId.isValid(dataType) && PostgresqlObjectId.valueOf(dataType) != getDefaultType()) {
                 return false;
             }
         }

--- a/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
+++ b/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
@@ -399,12 +399,7 @@ public enum PostgresqlObjectId {
 
         if (objectId >= 0 && objectId < OID_CACHE_SIZE) {
             PostgresqlObjectId oid = CACHE[objectId];
-
-            if (oid == null) {
-                return false;
-            }
-
-            return true;
+            return oid == null ? false : true;
         }
 
         try {

--- a/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
+++ b/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
@@ -399,7 +399,7 @@ public enum PostgresqlObjectId {
 
         if (objectId >= 0 && objectId < OID_CACHE_SIZE) {
             PostgresqlObjectId oid = CACHE[objectId];
-            return oid == null ? false : true;
+            return oid != null;
         }
 
         try {

--- a/src/test/java/io/r2dbc/postgresql/codec/InstantCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/InstantCodecUnitTests.java
@@ -43,6 +43,11 @@ final class InstantCodecUnitTests {
     private static final int dataType = TIMESTAMP.getObjectId();
 
     @Test
+    void cannotDecodeCustomType() {
+        assertThat(new InstantCodec(TEST).canDecode(72093, FORMAT_TEXT, Object.class)).isFalse();
+    }
+
+    @Test
     void constructorNoByteBufAllocator() {
         assertThatIllegalArgumentException().isThrownBy(() -> new InstantCodec(null))
             .withMessage("byteBufAllocator must not be null");

--- a/src/test/java/io/r2dbc/postgresql/codec/IntegerCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/IntegerCodecUnitTests.java
@@ -44,6 +44,11 @@ final class IntegerCodecUnitTests {
     }
 
     @Test
+    void cannotDecodeCustomType() {
+        assertThat(new IntegerCodec(TEST).canDecode(72093, FORMAT_TEXT, Object.class)).isFalse();
+    }
+
+    @Test
     void decode() {
         IntegerCodec codec = new IntegerCodec(TEST);
 


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->
closes #301

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description
#301 

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
