### PR TITLE
Add Option<LoopResources> tcpLoopResources

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 
 | Option            | Description
 | ----------------- | -----------
-| `ssl`             | Enables SSL usage (`SSLMode.VERIFY_FULL`)
+| `ssl`             | Enables SSL usage (`SSLMode.VERIFY_FULL`).
 | `driver`          | Must be `postgresql`.
-| `host`            | Server hostname to connect to
+| `host`            | Server hostname to connect to.
 | `port`            | Server port to connect to.  Defaults to `5432`. _(Optional)_
 | `socket`          | Unix Domain Socket path to connect to as alternative to TCP. _(Optional)_
-| `username`        | Login username
-| `password`        | Login password _(Optional when using TLS Certificate authentication)_
+| `username`        | Login username.
+| `password`        | Login password. _(Optional when using TLS Certificate authentication)_
 | `database`        | Database to select. _(Optional)_
 | `applicationName` | The name of the application connecting to the database.  Defaults to `r2dbc-postgresql`. _(Optional)_
 | `autodetectExtensions` | Whether to auto-detect and register `Extension`s from the class path.  Defaults to `true`. _(Optional)_
@@ -92,7 +92,8 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `sslPassword`     | Key password to decrypt SSL key. _(Optional)_
 | `sslHostnameVerifier` | `javax.net.ssl.HostnameVerifier` implementation. _(Optional)_
 | `tcpNoDelay`      | Enabled/disable TCP NoDelay. Disabled by default. _(Optional)_
-| `tcpKeepAlive`    | Enabled/disable TCP KeepAlive. Disabled by default _(Optional)_
+| `tcpKeepAlive`    | Enabled/disable TCP KeepAlive. Disabled by default. _(Optional)_
+| `tcpLoopResources`| TCP LoopResources. _(Optional)_
 
 **Programmatic Configuration**
 

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -24,6 +24,7 @@ import io.r2dbc.postgresql.util.LogLevel;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
+import reactor.netty.resources.LoopResources;
 
 import javax.net.ssl.HostnameVerifier;
 import java.util.LinkedHashMap;
@@ -151,6 +152,13 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
     public static final Option<Boolean> TCP_NODELAY = Option.valueOf("tcpNoDelay");
 
     /**
+     * TCP {@link LoopResources}.
+     *
+     * @since 1.0.0
+     */
+    public static final Option<LoopResources> TCP_LOOP_RESOURCES = Option.valueOf("tcpLoopResources");
+
+    /**
      * Determine the number of queries that are cached in each connection.
      * The default is {@code -1}, meaning there's no limit. The value of {@code 0} disables the cache. Any other value specifies the cache size.
      */
@@ -224,6 +232,7 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
         });
         mapper.from(TCP_KEEPALIVE).map(OptionMapper::toBoolean).to(builder::tcpKeepAlive);
         mapper.from(TCP_NODELAY).map(OptionMapper::toBoolean).to(builder::tcpNoDelay);
+        mapper.from(TCP_LOOP_RESOURCES).to(builder::tcpLoopResources);
         builder.username(options.getRequiredValue(USER));
 
         return builder;

--- a/src/test/java/io/r2dbc/postgresql/client/ConnectionSettingsUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ConnectionSettingsUnitTests.java
@@ -19,9 +19,16 @@ package io.r2dbc.postgresql.client;
 import io.r2dbc.postgresql.util.LogLevel;
 import org.junit.jupiter.api.Test;
 import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.resources.LoopResources;
+import reactor.netty.tcp.TcpResources;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link ConnectionSettings}.
@@ -54,12 +61,16 @@ final class ConnectionSettingsUnitTests {
 
     @Test
     void build() {
-
+        LoopResources loopResources = mock(LoopResources.class);
         ConnectionSettings connectionSettings =
-            ConnectionSettings.builder().connectionProvider(ConnectionProvider.newConnection()).errorResponseLogLevel(LogLevel.OFF).noticeLogLevel(LogLevel.ERROR).sslConfig(new SSLConfig(SSLMode.DISABLE, null, null)).build();
+            ConnectionSettings.builder().connectionProvider(ConnectionProvider.newConnection())
+                .tcpLoopResources(loopResources)
+                .errorResponseLogLevel(LogLevel.OFF).noticeLogLevel(LogLevel.ERROR)
+                .sslConfig(new SSLConfig(SSLMode.DISABLE, null, null)).build();
 
         assertThat(connectionSettings)
             .hasFieldOrPropertyWithValue("connectionProvider", ConnectionProvider.newConnection())
+            .hasFieldOrPropertyWithValue("tcpLoopResources", loopResources)
             .hasFieldOrPropertyWithValue("errorResponseLogLevel", LogLevel.OFF)
             .hasFieldOrPropertyWithValue("noticeLogLevel", LogLevel.ERROR)
             .hasFieldOrProperty("sslConfig");
@@ -67,18 +78,36 @@ final class ConnectionSettingsUnitTests {
 
     @Test
     void mutate() {
-
         ConnectionProvider foo = ConnectionProvider.builder("foo").build();
         ConnectionSettings connectionSettings =
-            ConnectionSettings.builder().connectionProvider(ConnectionProvider.newConnection()).errorResponseLogLevel(LogLevel.OFF).noticeLogLevel(LogLevel.ERROR).sslConfig(new SSLConfig(SSLMode.DISABLE, null, null)).build();
+            ConnectionSettings.builder().connectionProvider(ConnectionProvider.newConnection())
+                .tcpLoopResources(TcpResources.get())
+                .errorResponseLogLevel(LogLevel.OFF).noticeLogLevel(LogLevel.ERROR)
+                .connectTimeout(Duration.ofSeconds(30)).tcpKeepAlive(true).tcpNoDelay(true)
+                .sslConfig(new SSLConfig(SSLMode.DISABLE, null, null)).build();
 
         ConnectionSettings mutated = connectionSettings.mutate(builder -> builder.connectionProvider(foo));
 
         assertThat(mutated)
             .hasFieldOrPropertyWithValue("connectionProvider", foo)
+            .hasFieldOrPropertyWithValue("tcpLoopResources", TcpResources.get())
             .hasFieldOrPropertyWithValue("errorResponseLogLevel", LogLevel.OFF)
             .hasFieldOrPropertyWithValue("noticeLogLevel", LogLevel.ERROR)
+            .hasFieldOrPropertyWithValue("connectTimeout", Duration.ofSeconds(30))
+            .hasFieldOrPropertyWithValue("tcpKeepAlive", true)
+            .hasFieldOrPropertyWithValue("tcpNoDelay", true)
             .hasFieldOrProperty("sslConfig");
+    }
+
+    @Test
+    void mutateLoopResources() {
+        LoopResources loopResources1 = mock(LoopResources.class);
+        LoopResources loopResources2 = mock(LoopResources.class);
+        ConnectionSettings connectionSettings = ConnectionSettings.builder().tcpLoopResources(loopResources1).build();
+
+        ConnectionSettings mutated = connectionSettings.mutate(builder -> builder.tcpLoopResources(loopResources2));
+
+        assertThat(mutated).hasFieldOrPropertyWithValue("tcpLoopResources", loopResources2);
     }
 
 }


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
As #319 said, tcp `LoopResource` could not be configured.

#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

Added `tcpLoopResources` connection option.



#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->

The `tcpLoopResources` only affect TCP sockets.
Unix domain socket still uses `SocketLoopResources`.

[resolves #319]