### PR TITLE
Use RoundRobinInetAddressResolver for DNS resolution

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/client/BalancedResolverGroup.java
+++ b/src/main/java/io/r2dbc/postgresql/client/BalancedResolverGroup.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.client;
+
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultNameResolver;
+import io.netty.resolver.RoundRobinInetAddressResolver;
+import io.netty.util.concurrent.EventExecutor;
+
+import java.net.InetSocketAddress;
+
+/**
+ * When the {@link InetSocketAddress} resolves to multiple IP addresses, pick one randomly.
+ *
+ * @since 0.8.6
+ */
+final class BalancedResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+    BalancedResolverGroup() {
+    }
+
+    public static final BalancedResolverGroup INSTANCE = new BalancedResolverGroup();
+
+    @Override
+    protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
+        return new RoundRobinInetAddressResolver(executor, new DefaultNameResolver(executor)).asAddressResolver();
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -370,6 +370,8 @@ public final class ReactorNettyClient implements Client {
                 tcpClient = tcpClient.runOn(settings.getRequiredLoopResources());
             }
 
+            tcpClient = tcpClient.resolver(new BalancedResolverGroup());
+
             tcpClient = tcpClient.option(ChannelOption.SO_KEEPALIVE, settings.isTcpKeepAlive());
             tcpClient = tcpClient.option(ChannelOption.TCP_NODELAY, settings.isTcpNoDelay());
         }


### PR DESCRIPTION
#### Issue description

As an alternative to #120 this solution will allow the client to connect to a postgres master/slave setup through multiple pgbouncers.

#### Considerations

This is impossible to unit test properly, but I can provide credentials to manually test the behavior of the resolver.

This change should be backwards compatible, so I didn't make the resolving behavior configurable.

#### Which Version?
Should this feature be merged to main or also to the 0.8.x branch?