### PR TITLE
support postgres's 40001 error code

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/ExceptionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/ExceptionFactory.java
@@ -68,6 +68,7 @@ final class ExceptionFactory {
             case "42501":
                 return new PostgresqlPermissionDeniedException(errorDetails);
             case "40000":
+            case "40001":
                 return new PostgresqlRollbackException(errorDetails);
             case "28000":
             case "28P01":


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Currently `r2dbc-postgresql` driver does not support 40001 error code (serialization_failure).
When the driver is used with `org.springframework.boot:spring-boot-starter-data-r2dbc` and db returns 40001, `io.r2dbc.postgresql.ExceptionFactory` puts this error in `io.r2dbc.postgresql.PostgresqlTransientException`
and then in `org.springframework.r2dbc.connection.ConnectionFactoryUtils` it is wrapped in `org.springframework.r2dbc.UncategorizedR2dbcException`.
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
