### PR TITLE
Support dollar sign as query parameter value in simple queries

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatement.java
@@ -136,7 +136,18 @@ final class SimpleQueryPostgresqlStatement implements PostgresqlStatement {
     static boolean supports(String sql) {
         Assert.requireNonNull(sql, "sql must not be null");
 
-        return sql.trim().isEmpty() || !sql.contains("$1");
+        boolean singleQuoteOpened = false;
+        for (int i = 0; i < sql.length(); i++) {
+            final char currentSymbol = sql.charAt(i);
+            if (currentSymbol == '\'') {
+                singleQuoteOpened = !singleQuoteOpened;
+            }
+            if (!singleQuoteOpened && currentSymbol == '$') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private Flux<io.r2dbc.postgresql.api.PostgresqlResult> execute(String sql) {

--- a/src/test/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatementUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatementUnitTests.java
@@ -334,4 +334,8 @@ final class SimpleQueryPostgresqlStatementUnitTests {
         assertThat(SimpleQueryPostgresqlStatement.supports("test-query")).isTrue();
     }
 
+    @Test
+    void supportsDollarSignAsValue() {
+        assertThat(SimpleQueryPostgresqlStatement.supports("INSERT INTO user(password) VALUES ('$1$2 test value$1')")).isTrue();
+    }
 }


### PR DESCRIPTION
[resolves #312]

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
