### PR TITLE
Fix readColumnFormats(...) to comply with postgresql decoding rules

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/message/backend/AbstractCopyResponse.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/AbstractCopyResponse.java
@@ -84,18 +84,17 @@ abstract class AbstractCopyResponse implements BackendMessage {
         Assert.requireNonNull(in, "in must not be null");
 
         int count = in.readShort();
+        Set<Format> formatSet = EnumSet.noneOf(Format.class);
 
-        switch (count) {
-            case 0:
-                return EnumSet.noneOf(Format.class);
-            default:
-                Set<Format> formatSet = EnumSet.noneOf(Format.class);
-                for (int i = 0; i < count; i++) {
-                    formatSet.add(Format.valueOf(in.readShort()));
-                }
-
-                return formatSet;
+        if (0 == count) {
+            return formatSet;
         }
+
+        for (int i = 0; i < count; i++) {
+            formatSet.add(Format.valueOf(in.readShort()));
+        }
+
+        return formatSet;
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/message/backend/AbstractCopyResponse.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/AbstractCopyResponse.java
@@ -88,11 +88,6 @@ abstract class AbstractCopyResponse implements BackendMessage {
         switch (count) {
             case 0:
                 return EnumSet.noneOf(Format.class);
-            case 1:
-                short format = in.readShort();
-                return format == 0 ? Format.text() : Format.binary();
-            case 2:
-                return Format.all();
             default:
                 Set<Format> formatSet = EnumSet.noneOf(Format.class);
                 for (int i = 0; i < count; i++) {

--- a/src/test/java/io/r2dbc/postgresql/message/backend/CopyOutResponseUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/message/backend/CopyOutResponseUnitTests.java
@@ -18,9 +18,11 @@ package io.r2dbc.postgresql.message.backend;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.EnumSet;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.message.backend.BackendMessageAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -49,6 +51,17 @@ final class CopyOutResponseUnitTests {
                 .writeShort(1)
                 .writeShort(1))
             .isEqualTo(new CopyOutResponse(EnumSet.of(FORMAT_BINARY), FORMAT_BINARY));
+    }
+
+    @Test
+    void decodeOverallFormatText() {
+        assertThat(CopyOutResponse.class)
+            .decoded(buffer -> buffer
+                .writeByte(0)
+                .writeShort(2)
+                .writeShort(0)
+                .writeShort(0))
+            .isEqualTo(new CopyOutResponse(Collections.unmodifiableSet(EnumSet.of(FORMAT_TEXT)), FORMAT_TEXT));
     }
 
 }


### PR DESCRIPTION
Now AbstractCopyResponse.readColumnFormats(...) does not assume what to do when there are only one or two columns but instead reads buffer contents

[resolves #367]
