### PR TITLE
[Issue #407] Fix for HStore special characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ hs_err_pid*
 .project
 .settings
 /bin/
+
+# VSCode
+.vscode/

--- a/src/main/java/io/r2dbc/postgresql/codec/HStoreCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/HStoreCodec.java
@@ -25,6 +25,8 @@ import io.r2dbc.postgresql.util.Assert;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -52,9 +54,9 @@ final class HStoreCodec implements Codec<Map> {
 
     }
 
+    private static final Class<Map> TYPE = Map.class;
+    
     private final ByteBufAllocator byteBufAllocator;
-
-    private final Class<Map> type = Map.class;
 
     private final int oid;
 
@@ -73,23 +75,21 @@ final class HStoreCodec implements Codec<Map> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        Assert.requireNonNull(type, "type must not be null");
-
-        return dataType == this.oid && type.isAssignableFrom(this.type);
+        return dataType == this.oid && type.isAssignableFrom(TYPE);
     }
 
     @Override
     public boolean canEncode(Object value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        return this.type.isInstance(value);
+        return TYPE.isInstance(value);
     }
 
     @Override
     public boolean canEncodeNull(Class<?> type) {
         Assert.requireNonNull(type, "type must not be null");
 
-        return this.type.isAssignableFrom(type);
+        return TYPE.isAssignableFrom(type);
     }
 
     @Override
@@ -126,10 +126,9 @@ final class HStoreCodec implements Codec<Map> {
 
     private static Map<String, String> decodeTextFormat(ByteBuf buffer) {
         Map<String, String> map = new LinkedHashMap<>();
-        StringBuilder mutableBuffer = new StringBuilder();
 
         while (buffer.isReadable()) {
-            String key = readString(mutableBuffer, buffer);
+            String key = readString(buffer);
             if (key == null) {
                 break;
             }
@@ -140,7 +139,7 @@ final class HStoreCodec implements Codec<Map> {
                 value = null;
                 buffer.skipBytes(4);// skip 'NULL'.
             } else {
-                value = readString(mutableBuffer, buffer);
+                value = readString(buffer);
             }
             map.put(key, value);
 
@@ -163,9 +162,10 @@ final class HStoreCodec implements Codec<Map> {
     }
 
     @Nullable
-    private static String readString(StringBuilder mutableBuffer, ByteBuf buffer) {
-        mutableBuffer.setLength(0);
+    private static String readString(ByteBuf buffer) {
+        ByteBuffer accBuffer = ByteBuffer.allocate(buffer.capacity());
         int position = buffer.forEachByte(new IndexOfProcessor((byte) '"'));
+
         if (position > buffer.writerIndex()) {
             return null;
         }
@@ -175,18 +175,21 @@ final class HStoreCodec implements Codec<Map> {
         }
 
         while (buffer.isReadable()) {
-            char c = (char) buffer.readByte();
+            byte b = buffer.readByte();
+            char c = (char) b;
+            
             if (c == '"') {
                 break;
-            } else if (c == '\\') {
-                c = (char) buffer.readByte();
             }
-            mutableBuffer.append(c);
+            
+            if (c == '\\') {
+                b = buffer.readByte();
+            }
+            
+            accBuffer.put(b);
         }
 
-        String result = mutableBuffer.toString();
-        mutableBuffer.setLength(0);
-        return result;
+        return new String(accBuffer.array(), 0, accBuffer.position(), UTF_8);
     }
 
     @Override
@@ -233,7 +236,7 @@ final class HStoreCodec implements Codec<Map> {
 
     @Override
     public Class<?> type() {
-        return this.type;
+        return TYPE;
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/codec/HStoreCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/HStoreCodecUnitTests.java
@@ -53,12 +53,14 @@ final class HStoreCodecUnitTests {
     @Test
     void decodeAsText() {
         ByteBuf buffer = TEST.buffer();
-        buffer.writeCharSequence("\"b\"=>\"\\\"2.2\", \"a\\\"\"=>\"1\", \"c\"=>NULL", Charset.defaultCharset());
+        buffer.writeCharSequence("\"b\"=>\"\\\"2.2\", \"a\\\"\"=>\"1\", \"c\"=>NULL, \"d\"=>\"Zoë\", \"é\"=>\"120°\"", Charset.defaultCharset());
         Map<String, String> res = new HStoreCodec(TEST, dataType).decode(buffer, dataType, Format.FORMAT_TEXT, Map.class);
         Map<String, String> expect = new HashMap<>();
         expect.put("a\"", "1");
         expect.put("b", "\"2.2");
         expect.put("c", null);
+        expect.put("d", "Zoë");
+        expect.put("é", "120°");
 
         Assertions.assertThat(res).isEqualTo(expect);
     }


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes. (_I tried my best, but I use VSCode and I don't think the Intellij style file works there 😅_)
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Resolves #407

As mentioned in the ticket above, to parse the strings in the HStore data value, the code is reading the data byte by byte. However, to get a string out of the bytes, each byte is cast from `byte` to `char`, but characters can be 16-bits long rather than 8-bits.

To avoid the cast, I accumulated the parsed result in a `ByteBuffer` rather than the `StringBuilder` so we don't lose bytes in the parsing process. Then the bytes from `ByteBuffer` are used to create a UTF-8 encoded string.

I'm not sure if there's a better approach for this, but accumulating the bytes themselves is the only way I could think to preserve the integrity of the parsed byte. 🙂 

I added a couple of test cases with special characters to back the changes. Additionally, I cleaned up a few things I came across while working on this (boy scout principle 😅), which I'm fine reverting if necessary.

As always, I'm happy to contribute to this awesome project. 🙂 

Cheers!