### PR TITLE
Introduce codec mapping caches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <junit.version>5.7.0</junit.version>
         <jmh.version>1.32</jmh.version>
         <mbr.version>0.2.0.RELEASE</mbr.version>
-        <logback.version>1.2.3</logback.version>
-        <mockito.version>3.11.2</mockito.version>
+        <logback.version>1.2.5</logback.version>
+        <mockito.version>3.12.4</mockito.version>
         <netty.version>4.1.66.Final</netty.version>
         <postgresql.version>42.2.23</postgresql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -265,7 +265,7 @@
                 <version>3.8.1</version>
                 <configuration>
                     <compilerArgs>
-<!--                        <arg>-Werror</arg>-->
+                        <arg>-Werror</arg>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-deprecation</arg>
                         <arg>-Xlint:-options</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -265,7 +265,7 @@
                 <version>3.8.1</version>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Werror</arg>
+<!--                        <arg>-Werror</arg>-->
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-deprecation</arg>
                         <arg>-Xlint:-options</arg>

--- a/src/jmh/java/io/r2dbc/postgresql/CodecRegistryBenchmarks.java
+++ b/src/jmh/java/io/r2dbc/postgresql/CodecRegistryBenchmarks.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.r2dbc.postgresql.codec.CodecFinderCacheImpl;
+import io.r2dbc.postgresql.codec.CodecFinderDefaultImpl;
+import io.r2dbc.postgresql.codec.Codecs;
+import io.r2dbc.postgresql.codec.DefaultCodecs;
+import io.r2dbc.postgresql.util.ByteBufUtils;
+import org.junit.platform.commons.annotation.Testable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.FLOAT4;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.FLOAT8;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.FLOAT8_ARRAY;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT2_ARRAY;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT4_ARRAY;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.TIMESTAMP;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+
+/**
+ * Benchmarks for codec encoding and decoding using cached enabled or disabled registries.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Testable
+public class CodecRegistryBenchmarks extends BenchmarkSettings {
+
+    @State(Scope.Benchmark)
+    public static class CodecRegistryHolder {
+
+        @Param({"10", "100", "1000"})
+        public int iterations;
+
+        final ByteBufAllocator byteBufAllocator = new UnpooledByteBufAllocator(false, true);
+
+        DefaultCodecs cacheEnabledRegistry = new DefaultCodecs(byteBufAllocator, false, new CodecFinderCacheImpl());
+
+        DefaultCodecs cacheDisabledRegistry = new DefaultCodecs(byteBufAllocator, false, new CodecFinderDefaultImpl());
+
+    }
+
+    private void decode(Codecs codecs, int iterations, Blackhole voodoo) {
+        for (int i = 0; i < iterations; i++) {
+            voodoo.consume(codecs.decode(
+                TEST.buffer(4).writeInt(200), INT4.getObjectId(), FORMAT_BINARY, Integer.class));
+            voodoo.consume(codecs.decode(
+                ByteBufUtils.encode(TEST, "100"), INT2.getObjectId(), FORMAT_TEXT, Short.class));
+            voodoo.consume(codecs.decode(
+                ByteBufUtils.encode(TEST, "-125.369"), FLOAT8.getObjectId(), FORMAT_TEXT, Double.class));
+            voodoo.consume(codecs.decode(
+                TEST.buffer(4).writeFloat(-65.369f), FLOAT4.getObjectId(), FORMAT_BINARY, Float.class));
+            voodoo.consume(
+                codecs.decode(
+                    ByteBufUtils.encode(TEST, "test"),
+                    VARCHAR.getObjectId(),
+                    FORMAT_TEXT,
+                    String.class));
+            voodoo.consume(
+                codecs.decode(
+                    ByteBufUtils.encode(TEST, "2018-11-04 15:35:00.847108"),
+                    TIMESTAMP.getObjectId(),
+                    FORMAT_TEXT,
+                    LocalDateTime.class));
+            voodoo.consume(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT2_ARRAY.getObjectId(), FORMAT_TEXT, Object.class));
+            voodoo.consume(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT4_ARRAY.getObjectId(), FORMAT_TEXT, Object.class));
+            voodoo.consume(codecs.decode(ByteBufUtils.encode(TEST, "{100.5,200.8}"), FLOAT8_ARRAY.getObjectId(), FORMAT_TEXT, Object.class));
+        }
+    }
+
+    @Benchmark
+    public void decodeWithCacheEnabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        decode(holder.cacheEnabledRegistry, holder.iterations, voodoo);
+    }
+
+    @Benchmark
+    public void decodeWithCacheDisabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        decode(holder.cacheDisabledRegistry, holder.iterations, voodoo);
+    }
+
+    private void encode(Codecs codecs, int iterations, Blackhole voodoo) {
+        for (int i = 0; i < iterations; i++) {
+            voodoo.consume(codecs.encode((short) 12));
+            voodoo.consume(codecs.encode(35698));
+            voodoo.consume(codecs.encode(-256.3698));
+            voodoo.consume(codecs.encode(85.7458f));
+            voodoo.consume(codecs.encode("A text value"));
+            voodoo.consume(codecs.encode(LocalDateTime.now()));
+            voodoo.consume(codecs.encode(new Long[]{100L, 200L}));
+            voodoo.consume(codecs.encode(new Double[]{100.5, 200.25}));
+            voodoo.consume(codecs.encodeNull(Integer.class));
+            voodoo.consume(codecs.encodeNull(String.class));
+            voodoo.consume(codecs.encodeNull(Double[].class));
+        }
+    }
+
+    @Benchmark
+    public void encodeWithCacheEnabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        encode(holder.cacheEnabledRegistry, holder.iterations, voodoo);
+    }
+
+    @Benchmark
+    public void encodeWithCacheDisabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        encode(holder.cacheDisabledRegistry, holder.iterations, voodoo);
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractBinaryCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractBinaryCodec.java
@@ -25,6 +25,7 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -72,6 +73,11 @@ abstract class AbstractBinaryCodec<T> extends AbstractCodec<T> implements ArrayC
     @Override
     public PostgresTypeIdentifier getArrayDataType() {
         return BYTEA_ARRAY;
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(BYTEA);
     }
 
     byte[] decode(Format format, ByteBuf byteBuf) {

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractGeometryCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractGeometryCodec.java
@@ -24,6 +24,7 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -110,6 +111,11 @@ abstract class AbstractGeometryCodec<T> extends AbstractCodec<T> implements Arra
     @Override
     public EncodedParameter encodeNull() {
         return createNull(Format.FORMAT_BINARY, this.postgresqlObjectId);
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(this.postgresqlObjectId);
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractJsonCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractJsonCodec.java
@@ -20,11 +20,17 @@ import io.r2dbc.postgresql.client.EncodedParameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.JSON;
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.JSONB;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 
 abstract class AbstractJsonCodec<T> extends AbstractCodec<T> {
+
+    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(JSON, JSONB);
 
     AbstractJsonCodec(Class<T> type) {
         super(type);
@@ -45,7 +51,12 @@ abstract class AbstractJsonCodec<T> extends AbstractCodec<T> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return JSONB == type || JSON == type;
+        return SUPPORTED_TYPES.contains(type);
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return SUPPORTED_TYPES.stream().map(PostgresTypeIdentifier.class::cast).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
@@ -27,6 +27,7 @@ import reactor.util.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.FLOAT4;
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.FLOAT8;
@@ -142,6 +143,11 @@ abstract class AbstractNumericCodec<T extends Number> extends AbstractCodec<T> i
     @Override
     public EncodedParameter encodeNull() {
         return createNull(FORMAT_BINARY, getDefaultType());
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return SUPPORTED_TYPES.stream().map(PostgresTypeIdentifier.class::cast).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/ArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ArrayCodec.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -200,6 +201,11 @@ class ArrayCodec<T> extends AbstractCodec<Object[]> {
             encodeAsText(byteBuf, value, this.delegate::encodeToText);
             return byteBuf;
         }, dataType);
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(this.dataType);
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/BlobCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BlobCodec.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.BYTEA;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -77,6 +78,11 @@ final class BlobCodec extends AbstractCodec<Blob> {
                 .concatWith(Flux.from(value.discard())
                     .then(Mono.empty()))
         );
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(BYTEA);
     }
 
     private static final class ByteABlob implements Blob {

--- a/src/main/java/io/r2dbc/postgresql/codec/BuiltinCodecSupport.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BuiltinCodecSupport.java
@@ -22,6 +22,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
+import java.util.Collections;
 import java.util.function.Function;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -85,6 +86,11 @@ abstract class BuiltinCodecSupport<T> extends AbstractCodec<T> implements ArrayC
     @Override
     public final EncodedParameter encodeNull() {
         return createNull(FORMAT_TEXT, this.postgresType);
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(this.postgresType);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ByteCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ByteCodec.java
@@ -78,4 +78,14 @@ final class ByteCodec extends AbstractCodec<Byte> implements ArrayCodecDelegate<
         return PostgresqlObjectId.INT2_ARRAY;
     }
 
+    @Override
+    public Iterable<Format> getFormats() {
+        return this.delegate.getFormats();
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/CharacterCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CharacterCodec.java
@@ -80,4 +80,14 @@ final class CharacterCodec extends AbstractCodec<Character> implements ArrayCode
         return PostgresqlObjectId.CHAR_ARRAY;
     }
 
+    @Override
+    public Iterable<Format> getFormats() {
+        return this.delegate.getFormats();
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/ClobCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ClobCodec.java
@@ -27,8 +27,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Arrays;
+
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.TEXT;
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 
 final class ClobCodec extends AbstractCodec<Clob> {
@@ -76,6 +79,16 @@ final class ClobCodec extends AbstractCodec<Clob> {
                 .concatWith(Flux.from(value.discard())
                     .then(Mono.empty()))
         );
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Arrays.asList(VARCHAR, TEXT);
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        return Arrays.asList(FORMAT_TEXT, FORMAT_BINARY);
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/Codec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/Codec.java
@@ -104,4 +104,18 @@ public interface Codec<T> {
      */
     Class<?> type();
 
+    /**
+     * Returns the collection of {@link Format} supported by this codec
+     *
+     * @return the formats
+     */
+    Iterable<Format> getFormats();
+
+    /**
+     * Returns the collection of {@link PostgresTypeIdentifier} this codec can handle
+     *
+     * @return the datatypes
+     */
+    Iterable<PostgresTypeIdentifier> getDataTypes();
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/CodecFinder.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CodecFinder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.message.Format;
+import reactor.util.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * Helper used to find a {@link Codec} for encoding or decoding actions from a provided list of codecs.
+ */
+public interface CodecFinder {
+
+    void updateCodecs(List<Codec<?>> codecs);
+
+    @Nullable
+    <T> Codec<T> findDecodeCodec(int dataType, Format format, Class<? extends T> type);
+
+    @Nullable
+    <T> Codec<T> findEncodeCodec(T value);
+
+    @Nullable
+    <T> Codec<T> findEncodeNullCodec(Class<T> type);
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/CodecFinderCacheImpl.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CodecFinderCacheImpl.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.util.Assert;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.lang.reflect.Array;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Cache implementation of the {@link CodecFinder}. This will keep the relevant {@link Codec} for the type, format and database type cached for faster access.
+ * In case the {@link Codec} can't be found in the cache, a fallback search using {@link CodecFinderDefaultImpl} will be done.
+ */
+public class CodecFinderCacheImpl implements CodecFinder {
+
+    private static final Logger LOG = Loggers.getLogger(CodecFinderCacheImpl.class);
+
+    List<Codec<?>> codecs = Collections.emptyList();
+
+    private final Map<Integer, Codec<?>> decodeCodecsCache = new ConcurrentHashMap<>();
+
+    private final Map<Integer, Codec<?>> encodeCodecsCache = new ConcurrentHashMap<>();
+
+    private final Map<Integer, Codec<?>> encodeNullCodecsCache = new ConcurrentHashMap<>();
+
+    private final CodecFinder fallBackFinder;
+
+    public CodecFinderCacheImpl() {
+        this(new CodecFinderDefaultImpl());
+    }
+
+    public CodecFinderCacheImpl(CodecFinder fallBackFinder) {
+        Assert.requireNonType(fallBackFinder, CodecFinderCacheImpl.class, "fallBackFinder must not be of type CodecFinderCacheImpl");
+        this.fallBackFinder = fallBackFinder;
+    }
+
+    private static <T> int generateCodecHash(int dataType, Format format, Class<? extends T> type) {
+        int hash = (dataType << 5) - dataType;
+        hash = (hash << 5) - hash + format.hashCode();
+        hash = (hash << 5) - hash + generateCodecHash(type);
+        return hash;
+    }
+
+    private static <T> int generateCodecHash(Class<? extends T> type) {
+        int hash = type.hashCode();
+        if (type.getComponentType() != null) {
+            hash = (hash << 5) - hash + generateCodecHash(type.getComponentType());
+        }
+        return hash;
+    }
+
+    void invalidateCaches() {
+        this.decodeCodecsCache.clear();
+        this.encodeCodecsCache.clear();
+        this.encodeNullCodecsCache.clear();
+        buildCaches();
+    }
+
+    void buildCaches() {
+        for (Codec<?> c : this.codecs) {
+            Optional<Class<?>> arrayClass = Optional.empty();
+            if (c instanceof ArrayCodec) {
+                ArrayCodec<?> ac = (ArrayCodec<?>) c;
+                arrayClass = Optional.of(Array.newInstance(ac.getComponentType(), 0).getClass());
+            }
+            cacheEncode(c, c.type());
+            arrayClass.ifPresent(ac -> cacheEncode(c, ac));
+            for (PostgresTypeIdentifier identifier : c.getDataTypes()) {
+                for (Format format : c.getFormats()) {
+                    cacheDecode(c, c.type(), identifier, format);
+                    arrayClass.ifPresent(ac -> cacheDecode(c, ac, identifier, format));
+                }
+            }
+        }
+        // Handle decode to Object.class support
+        for (PostgresqlObjectId identifier : PostgresqlObjectId.values()) {
+            for (Format format : Format.all()) {
+                Codec<?> c = fallBackFinder.findDecodeCodec(identifier.getObjectId(), format, Object.class);
+                if (c != null) {
+                    cacheDecode(c, Object.class, identifier, format);
+                }
+            }
+        }
+    }
+
+    private void cacheDecode(Codec<?> c, Class<?> type, PostgresTypeIdentifier identifier, Format format) {
+        int decodeHash = generateCodecHash(identifier.getObjectId(), format, type);
+        decodeCodecsCache.putIfAbsent(decodeHash, c);
+    }
+
+    private void cacheEncode(Codec<?> c, Class<?> type) {
+        int encodeHash = generateCodecHash(type);
+        encodeCodecsCache.putIfAbsent(encodeHash, c);
+        if (c.canEncodeNull(type)) {
+            encodeNullCodecsCache.putIfAbsent(encodeHash, c);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    synchronized <T> Codec<T> findCodec(int codecHash, Map<Integer, Codec<?>> cache, Supplier<Codec<T>> fallback) {
+        return Optional.ofNullable((Codec<T>) cache.get(codecHash)).orElseGet(fallback);
+    }
+
+    @Override
+    public synchronized void updateCodecs(List<Codec<?>> codecs) {
+        this.codecs = codecs;
+        fallBackFinder.updateCodecs(codecs);
+        invalidateCaches();
+    }
+
+    @Override
+    public <T> Codec<T> findDecodeCodec(int dataType, Format format, Class<? extends T> type) {
+        int hash = generateCodecHash(dataType, format, type);
+        return findCodec(hash, decodeCodecsCache, () -> {
+            LOG.trace("[codec-finder dataType={}, format={}, type={}] Decode codec not found in cache", dataType, format, type.getName());
+            Codec<T> c = fallBackFinder.findDecodeCodec(dataType, format, type);
+            if (c != null) {
+                decodeCodecsCache.putIfAbsent(hash, c);
+            }
+            return c;
+        });
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeCodec(T value) {
+        int hash = generateCodecHash(value.getClass());
+        return findCodec(hash, encodeCodecsCache, () -> {
+            LOG.trace("[codec-finder type={}] Encode codec not found in cache", value.getClass().getName());
+            Codec<T> c = fallBackFinder.findEncodeCodec(value);
+            if (c != null) {
+                encodeCodecsCache.putIfAbsent(hash, c);
+            }
+            return c;
+        });
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeNullCodec(Class<T> type) {
+        int hash = generateCodecHash(type);
+        return findCodec(hash, encodeNullCodecsCache, () -> {
+            LOG.trace("[codec-finder type={}] Encode null codec not found in cache", type.getName());
+            Codec<T> c = fallBackFinder.findEncodeNullCodec(type);
+            if (c != null) {
+                encodeNullCodecsCache.putIfAbsent(hash, c);
+            }
+            return c;
+        });
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImpl.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.message.Format;
+import reactor.util.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Default implementation of the {@link CodecFinder}. This will systematically search for {@link Codec} for the type, format and database type
+ * by calling the methods {@link Codec#canDecode}, {@link Codec#canEncode} and {@link Codec#canEncodeNull} on each registered codecs.
+ */
+public class CodecFinderDefaultImpl implements CodecFinder {
+
+    List<Codec<?>> codecs = Collections.emptyList();
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    synchronized <T> Codec<T> findCodec(Predicate<Codec<?>> predicate) {
+        for (Codec<?> codec : codecs) {
+            if (predicate.test(codec)) {
+                return (Codec<T>) codec;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized void updateCodecs(List<Codec<?>> codecs) {
+        this.codecs = codecs;
+    }
+
+    @Override
+    public <T> Codec<T> findDecodeCodec(int dataType, Format format, Class<? extends T> type) {
+        return findCodec(codec -> codec.canDecode(dataType, format, type));
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeCodec(T value) {
+        return findCodec(codec -> codec.canEncode(value));
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeNullCodec(Class<T> type) {
+        return findCodec(codec -> codec.canEncodeNull(type));
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/DateCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DateCodec.java
@@ -44,6 +44,11 @@ final class DateCodec extends AbstractCodec<Date> implements ArrayCodecDelegate<
     }
 
     @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
+    @Override
     boolean doCanDecode(PostgresqlObjectId type, Format format) {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");

--- a/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
@@ -29,11 +29,14 @@ import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static io.r2dbc.postgresql.client.EncodedParameter.NULL_VALUE;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 
 /**
@@ -112,6 +115,16 @@ public class EnumCodec<T extends Enum<T>> implements Codec<T> {
     @Override
     public Class<?> type() {
         return this.type;
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        return EnumSet.of(FORMAT_TEXT, FORMAT_BINARY);
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(AbstractCodec.getDataType(oid));
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/IntervalCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/IntervalCodec.java
@@ -22,6 +22,8 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
+import java.util.EnumSet;
+
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INTERVAL;
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INTERVAL_ARRAY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -43,6 +45,11 @@ final class IntervalCodec extends BuiltinCodecSupport<Interval> {
     @Override
     Interval doDecode(ByteBuf buffer, PostgresTypeIdentifier dataType, Format format, Class<? extends Interval> type) {
         return Interval.parse(ByteBufUtils.decode(buffer));
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        return EnumSet.of(FORMAT_TEXT);
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/RefCursorCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/RefCursorCodec.java
@@ -26,6 +26,8 @@ import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Collections;
+
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.REF_CURSOR;
 
 final class RefCursorCodec extends AbstractCodec<RefCursor> {
@@ -39,6 +41,11 @@ final class RefCursorCodec extends AbstractCodec<RefCursor> {
     @Override
     public EncodedParameter encodeNull() {
         throw new UnsupportedOperationException("RefCursor cannot be encoded");
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(REF_CURSOR);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/RefCursorNameCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/RefCursorNameCodec.java
@@ -23,6 +23,8 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
+import java.util.Collections;
+
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.REF_CURSOR;
 
 final class RefCursorNameCodec extends AbstractCodec<String> {
@@ -36,6 +38,11 @@ final class RefCursorNameCodec extends AbstractCodec<String> {
     @Override
     public EncodedParameter encodeNull() {
         throw new UnsupportedOperationException("Cannot encode RefCursor");
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return Collections.singleton(REF_CURSOR);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
@@ -24,6 +24,10 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.BPCHAR;
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.CHAR;
 import static io.r2dbc.postgresql.codec.PostgresqlObjectId.NAME;
@@ -34,6 +38,8 @@ import static io.r2dbc.postgresql.codec.PostgresqlObjectId.VARCHAR_ARRAY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 
 final class StringCodec extends AbstractCodec<String> implements ArrayCodecDelegate<String> {
+
+    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(BPCHAR, CHAR, TEXT, UNKNOWN, VARCHAR, NAME);
 
     private final ByteBufAllocator byteBufAllocator;
 
@@ -52,7 +58,7 @@ final class StringCodec extends AbstractCodec<String> implements ArrayCodecDeleg
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return BPCHAR == type || CHAR == type || TEXT == type || UNKNOWN == type || VARCHAR == type || NAME == type;
+        return SUPPORTED_TYPES.contains(type);
     }
 
     @Override
@@ -84,6 +90,11 @@ final class StringCodec extends AbstractCodec<String> implements ArrayCodecDeleg
     @Override
     public PostgresTypeIdentifier getArrayDataType() {
         return VARCHAR_ARRAY;
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return SUPPORTED_TYPES.stream().map(PostgresTypeIdentifier.class::cast).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/StringCodecDelegate.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringCodecDelegate.java
@@ -93,4 +93,14 @@ class StringCodecDelegate<T> extends AbstractCodec<T> implements ArrayCodecDeleg
         return PostgresqlObjectId.VARCHAR_ARRAY;
     }
 
+    @Override
+    public Iterable<Format> getFormats() {
+        return this.delegate.getFormats();
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
 }

--- a/src/main/resources/META-INF/services/io.r2dbc.postgresql.codec.CodecFinder
+++ b/src/main/resources/META-INF/services/io.r2dbc.postgresql.codec.CodecFinder
@@ -1,0 +1,1 @@
+io.r2dbc.postgresql.codec.CodecFinderCacheImpl

--- a/src/test/java/io/r2dbc/postgresql/CodecExtensionIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/CodecExtensionIntegrationTests.java
@@ -22,6 +22,7 @@ import io.r2dbc.postgresql.api.PostgresqlResult;
 import io.r2dbc.postgresql.client.EncodedParameter;
 import io.r2dbc.postgresql.codec.Codec;
 import io.r2dbc.postgresql.codec.CodecRegistry;
+import io.r2dbc.postgresql.codec.PostgresTypeIdentifier;
 import io.r2dbc.postgresql.codec.PostgresqlObjectId;
 import io.r2dbc.postgresql.extension.CodecRegistrar;
 import io.r2dbc.postgresql.message.Format;
@@ -32,6 +33,9 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.util.Collections;
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -145,6 +149,16 @@ final class CodecExtensionIntegrationTests extends AbstractIntegrationTests {
         @Override
         public Class<?> type() {
             return Json.class;
+        }
+
+        @Override
+        public Iterable<Format> getFormats() {
+            return EnumSet.of(Format.FORMAT_TEXT, Format.FORMAT_BINARY);
+        }
+
+        @Override
+        public Iterable<PostgresTypeIdentifier> getDataTypes() {
+            return Collections.singleton(PostgresqlObjectId.JSON);
         }
     }
 

--- a/src/test/java/io/r2dbc/postgresql/FetchSizeIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/FetchSizeIntegrationTests.java
@@ -73,7 +73,7 @@ final class FetchSizeIntegrationTests extends AbstractIntegrationTests {
             .bind(0, 1)
             .execute()
             .flatMap(r -> r.map((row, meta) -> row.get(0, Integer.class)))
-            .limitRequest(20)
+            .take(20, true)
             .as(StepVerifier::create)
             .expectNextCount(20)
             .verifyComplete();
@@ -88,7 +88,7 @@ final class FetchSizeIntegrationTests extends AbstractIntegrationTests {
             .fetchSize(6)
             .execute()
             .flatMap(r -> r.map((row, meta) -> row.get(0, Integer.class)))
-            .limitRequest(20)
+            .take(20, true)
             .as(StepVerifier::create)
             .expectNextCount(20)
             .verifyComplete();

--- a/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientIntegrationTests.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.util.ReflectionUtils;
 import reactor.core.publisher.Flux;
@@ -312,6 +314,7 @@ final class ReactorNettyClientIntegrationTests {
     }
 
     @Test
+    @DisabledOnOs({OS.MAC, OS.WINDOWS})
     void unixDomainSocketTest() {
 
         String socket = "/tmp/.s.PGSQL.5432";

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecFinderCacheImplUnitTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecFinderCacheImplUnitTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.FLOAT8;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@ExtendWith(MockitoExtension.class)
+class CodecFinderCacheImplUnitTest {
+
+    DefaultCodecs codecs;
+
+    CodecFinderCacheImpl codecFinder;
+
+    @Spy
+    CodecFinderDefaultImpl fallBackFinder = new CodecFinderDefaultImpl();
+
+    @Captor
+    ArgumentCaptor<Map<Integer, Codec<?>>> cacheArgumentCaptor;
+
+    @Mock
+    Codec<String> stringCodec;
+
+    @Mock
+    Codec<Integer> integerCodec;
+
+    @BeforeEach
+    void setUp() {
+        codecFinder = new CodecFinderCacheImpl(fallBackFinder);
+        // We use the DefaultCodecs to populate the cache with some codecs
+        codecs = new DefaultCodecs(TEST, false, codecFinder);
+    }
+
+    @Test
+    void fallbackFinder_same_class() {
+        assertThatThrownBy(() -> new CodecFinderCacheImpl(codecFinder)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void findCodec() {
+        List<Codec<?>> codecList = Arrays.asList(stringCodec, integerCodec);
+        doReturn(String.class).when(stringCodec).type();
+        doReturn(Collections.singleton((PostgresTypeIdentifier) VARCHAR)).when(stringCodec).getDataTypes();
+        doReturn(EnumSet.of(FORMAT_TEXT)).when(stringCodec).getFormats();
+        doReturn(Integer.class).when(integerCodec).type();
+        doReturn(Collections.singleton((PostgresTypeIdentifier) INT4)).when(integerCodec).getDataTypes();
+        doReturn(EnumSet.of(FORMAT_TEXT)).when(integerCodec).getFormats();
+        codecFinder.updateCodecs(codecList);
+        assertThat(codecFinder.findDecodeCodec(INT4.getObjectId(), FORMAT_TEXT, Integer.class)).isEqualTo(integerCodec);
+        assertThat(codecFinder.findDecodeCodec(VARCHAR.getObjectId(), FORMAT_TEXT, String.class)).isEqualTo(stringCodec);
+        assertThat(codecFinder.findDecodeCodec(FLOAT8.getObjectId(), FORMAT_TEXT, Double.class)).isNull();
+    }
+
+    @Test
+    void findDecodeCodecShort() {
+        CodecFinderCacheImpl spyCodecs = spy(codecFinder);
+        Codec<Short> shortCodec = spyCodecs.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, Short.class);
+        assertThat(shortCodec).isNotNull();
+    }
+
+    @Test
+    void findDecodeCodecNotFound() {
+        assertThat(codecFinder.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, DefaultCodecsUnitTests.class)).isNull();
+    }
+
+    @Test
+    void findEncodeCodecDouble() {
+        CodecFinderCacheImpl spyCodecs = spy(codecFinder);
+        Codec<?> doubleCodec = spyCodecs.findEncodeCodec(1.2);
+        assertThat(doubleCodec).isInstanceOf(DoubleCodec.class);
+    }
+
+    @Test
+    void findEncodeCodecNotFound() {
+        assertThat(codecFinder.findEncodeCodec(this)).isNull();
+    }
+
+    @Test
+    void findEncodeNullCodecInteger() {
+        CodecFinderCacheImpl spyCodecs = spy(codecFinder);
+        Codec<?> intCodec = spyCodecs.findEncodeNullCodec(Integer.class);
+        assertThat(intCodec).isInstanceOf(IntegerCodec.class);
+    }
+
+    @Test
+    void findEncodeNullCodecNotFound() {
+        assertThat(codecFinder.findEncodeNullCodec(DefaultCodecsUnitTests.class)).isNull();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImplUnitTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImplUnitTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static io.r2dbc.postgresql.codec.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CodecFinderDefaultImplUnitTest {
+
+    DefaultCodecs codecs;
+
+    @Spy
+    CodecFinderDefaultImpl codecFinder = new CodecFinderDefaultImpl();
+
+    @Captor
+    ArgumentCaptor<Predicate<Codec<?>>> predicateArgumentCaptor;
+
+    @Mock
+    Codec<String> stringCodec;
+
+    @Mock
+    Codec<Integer> integerCodec;
+
+    @BeforeEach
+    void setUp() {
+        // We use the DefaultCodecs to populate the cache with some codecs
+        codecs = new DefaultCodecs(TEST, false, codecFinder);
+    }
+
+    @Test
+    void findCodec_notFound() {
+        List<Codec<?>> codecList = Arrays.asList(stringCodec, integerCodec);
+        codecFinder.updateCodecs(codecList);
+        doReturn(false).when(stringCodec).canEncode(this);
+        doReturn(false).when(integerCodec).canEncode(this);
+        assertThat(codecFinder.findCodec(c -> c.canEncode(this))).isNull();
+    }
+
+    @Test
+    void findCodec_found() {
+        List<Codec<?>> codecList = Arrays.asList(stringCodec, integerCodec);
+        codecFinder.updateCodecs(codecList);
+        doReturn(false).when(stringCodec).canEncode(this);
+        doReturn(true).when(integerCodec).canEncode(this);
+        assertThat(codecFinder.findCodec(c -> c.canEncode(this))).isEqualTo(integerCodec);
+    }
+
+    @Test
+    void findDecodeCodecShort() {
+        Codec<Short> shortCodec = codecFinder.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, Short.class);
+        assertThat(shortCodec).isNotNull();
+        verify(codecFinder).findCodec(predicateArgumentCaptor.capture());
+    }
+
+    @Test
+    void findDecodeCodecNotFound() {
+        assertThat(codecFinder.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, this.getClass())).isNull();
+    }
+
+    @Test
+    void findEncodeCodecDouble() {
+        Codec<?> doubleCodec = codecFinder.findEncodeCodec(1.2);
+        assertThat(doubleCodec).isInstanceOf(DoubleCodec.class);
+        verify(codecFinder).findCodec(predicateArgumentCaptor.capture());
+    }
+
+    @Test
+    void findEncodeCodecNotFound() {
+        assertThat(codecFinder.findEncodeCodec(this)).isNull();
+    }
+
+    @Test
+    void findEncodeNullCodecInteger() {
+        Codec<?> intCodec = codecFinder.findEncodeNullCodec(Integer.class);
+        assertThat(intCodec).isInstanceOf(IntegerCodec.class);
+        verify(codecFinder).findCodec(predicateArgumentCaptor.capture());
+    }
+
+    @Test
+    void findEncodeNullCodecNotFound() {
+        assertThat(codecFinder.findEncodeNullCodec(DefaultCodecsUnitTests.class)).isNull();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/MockCodec.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/MockCodec.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Mock imoplementation of {@link Codec}.
@@ -59,6 +60,11 @@ public final class MockCodec<T> extends AbstractCodec<T> {
     @Override
     public EncodedParameter encodeNull() {
         return this.encodings.get(null);
+    }
+
+    @Override
+    public Iterable<PostgresTypeIdentifier> getDataTypes() {
+        return canDecodes.stream().map(cd -> cd.type).collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes #409

Introduce codec mapping caches to improve encoding and decoding performances.

* Switched the codec list to a thread safe variant to avoid the synchronized blocks. Even though `CopyOnWriteArrayList` is not super performant it should work fine in this context where the list should not be frequently updated.
* Switched `mockito-core` to `mockito-junit-jupiter` for Junit 5 support

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

See gh-409
<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
