### PR TITLE
#381 Add builder method to set statement and lock timeout

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -49,8 +49,10 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.client.TransactionStatus.IDLE;
 import static io.r2dbc.postgresql.client.TransactionStatus.OPEN;
@@ -420,6 +422,22 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
                 return String.format("SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL %s", isolationLevel.asSql());
             }
         };
+    }
+
+    @Override
+    public Mono<Void> lockTimeout(Duration lockTimeout) {
+        Assert.requireNonNull(lockTimeout, "lockTimeout must not be null");
+
+        Flux<?> exchange = exchange(String.format("SET LOCK_TIMEOUT = %s", lockTimeout.toMillis()));
+        return Mono.defer(() -> Mono.from(exchange).then());
+    }
+
+    @Override
+    public Mono<Void> statementTimeout(Duration statementTimeout) {
+        Assert.requireNonNull(statementTimeout, "statementTimeout must not be null");
+
+        Flux<?> exchange = exchange(String.format("SET STATEMENT_TIMEOUT = %s", statementTimeout.toMillis()));
+        return Mono.defer(() -> Mono.from(exchange).then());
     }
 
     private Mono<Void> useTransactionStatus(Function<TransactionStatus, Publisher<?>> f) {

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
@@ -87,6 +87,9 @@ public final class PostgresqlConnectionConfiguration {
     private final String host;
 
     @Nullable
+    private final Duration lockTimeout;
+
+    @Nullable
     private final LoopResources loopResources;
 
     private final LogLevel noticeLogLevel;
@@ -101,6 +104,9 @@ public final class PostgresqlConnectionConfiguration {
 
     private final int preparedStatementCacheQueries;
 
+    @Nullable
+    private final Duration statementTimeout;
+
     private final String socket;
 
     private final SSLConfig sslConfig;
@@ -111,16 +117,12 @@ public final class PostgresqlConnectionConfiguration {
 
     private final String username;
 
-    private final Duration statementTimeout;
-
-    private final Duration lockTimeout;
-
     private PostgresqlConnectionConfiguration(String applicationName, boolean autodetectExtensions, @Nullable boolean compatibilityMode, Duration connectTimeout, @Nullable String database,
                                               LogLevel errorResponseLogLevel,
-                                              List<Extension> extensions, ToIntFunction<String> fetchSize, boolean forceBinary, @Nullable String host, @Nullable LoopResources loopResources,
+                                              List<Extension> extensions, ToIntFunction<String> fetchSize, boolean forceBinary, @Nullable String host, @Nullable Duration lockTimeout, @Nullable LoopResources loopResources,
                                               LogLevel noticeLogLevel, @Nullable Map<String, String> options, @Nullable CharSequence password, int port, boolean preferAttachedBuffers,
-                                              int preparedStatementCacheQueries, @Nullable String schema, @Nullable String socket, SSLConfig sslConfig, boolean tcpKeepAlive, boolean tcpNoDelay,
-                                              String username, @Nullable Duration statementTimeout, @Nullable Duration lockTimeout) {
+                                              int preparedStatementCacheQueries, @Nullable String schema, @Nullable String socket, SSLConfig sslConfig, @Nullable Duration statementTimeout, boolean tcpKeepAlive, boolean tcpNoDelay,
+                                              String username) {
         this.applicationName = Assert.requireNonNull(applicationName, "applicationName must not be null");
         this.autodetectExtensions = autodetectExtensions;
         this.compatibilityMode = compatibilityMode;
@@ -462,8 +464,8 @@ public final class PostgresqlConnectionConfiguration {
             return new PostgresqlConnectionConfiguration(this.applicationName, this.autodetectExtensions, this.compatibilityMode, this.connectTimeout, this.database, this.errorResponseLogLevel,
                 this.extensions,
                 this.fetchSize
-                , this.forceBinary, this.host, this.loopResources, this.noticeLogLevel, this.options, this.password, this.port, this.preferAttachedBuffers,
-                this.preparedStatementCacheQueries, this.schema, this.socket, this.createSslConfig(), this.tcpKeepAlive, this.tcpNoDelay, this.username, this.statementTimeout, this.lockTimeout);
+                , this.forceBinary, this.host, this.lockTimeout, this.loopResources, this.noticeLogLevel, this.options, this.password, this.port, this.preferAttachedBuffers,
+                this.preparedStatementCacheQueries, this.schema, this.socket, this.createSslConfig(), this.statementTimeout, this.tcpKeepAlive, this.tcpNoDelay, this.username);
         }
 
         /**

--- a/src/main/java/io/r2dbc/postgresql/api/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/api/PostgresqlConnection.java
@@ -26,6 +26,8 @@ import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 /**
  * A {@link Connection} for connecting to a PostgreSQL database.
  */
@@ -111,6 +113,13 @@ public interface PostgresqlConnection extends Connection {
     boolean isAutoCommit();
 
     /**
+     * Sets Lock Timeout by sending a query message to a server.
+     *
+     * @return a {@link Mono} that indicates that a lockTimeout frame was delivered to the backend
+     */
+    Mono<Void> lockTimeout(Duration lockTimeout);
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -139,6 +148,13 @@ public interface PostgresqlConnection extends Connection {
      */
     @Override
     Mono<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel);
+
+    /**
+     * Sets Statement Timeout by sending a query message to a server.
+     *
+     * @return a {@link Mono} that indicates that a statementTimeout frame was delivered to the backend
+     */
+    Mono<Void> statementTimeout(Duration statementTimeout);
 
     /**
      * {@inheritDoc}

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationUnitTests.java
@@ -76,20 +76,7 @@ final class PostgresqlConnectionConfigurationUnitTests {
         options.put("statement_timeout", "60000"); // [ms]
         LoopResources loopResources = mock(LoopResources.class);
 
-        PostgresqlConnectionConfiguration configuration = PostgresqlConnectionConfiguration.builder()
-            .applicationName("test-application-name")
-            .connectTimeout(Duration.ofMillis(1000))
-            .database("test-database")
-            .host("test-host")
-            .options(options)
-            .port(100)
-            .schema("test-schema")
-            .username("test-username")
-            .sslMode(SSLMode.ALLOW)
-            .tcpKeepAlive(true)
-            .tcpNoDelay(false)
-            .loopResources(loopResources)
-            .build();
+        PostgresqlConnectionConfiguration configuration = getPostgresqlConnectionConfiguration(options, loopResources).build();
 
         assertThat(configuration)
             .hasFieldOrPropertyWithValue("applicationName", "test-application-name")
@@ -109,6 +96,54 @@ final class PostgresqlConnectionConfigurationUnitTests {
             .containsEntry("lock_timeout", "10s")
             .containsEntry("statement_timeout", "60000")
             .containsEntry("search_path", "test-schema");
+    }
+
+    @Test
+    void configureStatementAndLockTimeouts() {
+        Map<String, String> options = new HashMap<>();
+        options.put("lock_timeout", "10s");
+        options.put("statement_timeout", "60000"); // [ms]
+        LoopResources loopResources = mock(LoopResources.class);
+
+        PostgresqlConnectionConfiguration configuration = getPostgresqlConnectionConfiguration(options, loopResources)
+            .statementTimeout(Duration.ofMillis(5000))
+            .lockTimeout(Duration.ofSeconds(50))
+            .build();
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("applicationName", "test-application-name")
+            .hasFieldOrPropertyWithValue("connectTimeout", Duration.ofMillis(1000))
+            .hasFieldOrPropertyWithValue("database", "test-database")
+            .hasFieldOrPropertyWithValue("host", "test-host")
+            .hasFieldOrProperty("options")
+            .hasFieldOrPropertyWithValue("password", null)
+            .hasFieldOrPropertyWithValue("port", 100)
+            .hasFieldOrPropertyWithValue("username", "test-username")
+            .hasFieldOrProperty("sslConfig")
+            .hasFieldOrPropertyWithValue("tcpKeepAlive", true)
+            .hasFieldOrPropertyWithValue("tcpNoDelay", false)
+            .hasFieldOrPropertyWithValue("loopResources", loopResources);
+
+        assertThat(configuration.getOptions())
+            .containsEntry("lock_timeout", "50000")
+            .containsEntry("statement_timeout", "5000")
+            .containsEntry("search_path", "test-schema");
+    }
+
+    private PostgresqlConnectionConfiguration.Builder getPostgresqlConnectionConfiguration(Map<String, String> options, LoopResources loopResources) {
+        return PostgresqlConnectionConfiguration.builder()
+            .applicationName("test-application-name")
+            .connectTimeout(Duration.ofMillis(1000))
+            .database("test-database")
+            .host("test-host")
+            .options(options)
+            .port(100)
+            .schema("test-schema")
+            .username("test-username")
+            .sslMode(SSLMode.ALLOW)
+            .tcpKeepAlive(true)
+            .tcpNoDelay(false)
+            .loopResources(loopResources);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionUnitTests.java
@@ -30,6 +30,7 @@ import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import static io.r2dbc.postgresql.client.TestClient.NO_OP;
@@ -497,6 +498,34 @@ final class PostgresqlConnectionUnitTests {
 
         createConnection(client, MockCodecs.empty(), this.statementCache)
             .setTransactionIsolationLevel(READ_COMMITTED)
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void setStatementTimeout() {
+        Client client = TestClient.builder()
+            .transactionStatus(IDLE)
+            .expectRequest(new Query(String.format("SET STATEMENT_TIMEOUT = %s", Duration.ofSeconds(2).toMillis())))
+            .thenRespond(new CommandComplete("SET", null, null))
+            .build();
+
+        createConnection(client, MockCodecs.empty(), this.statementCache)
+            .statementTimeout(Duration.ofSeconds(2))
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void setLockTimeout() {
+        Client client = TestClient.builder()
+            .transactionStatus(IDLE)
+            .expectRequest(new Query(String.format("SET LOCK_TIMEOUT = %s", Duration.ofSeconds(4).toMillis())))
+            .thenRespond(new CommandComplete("SET", null, null))
+            .build();
+
+        createConnection(client, MockCodecs.empty(), this.statementCache)
+            .lockTimeout(Duration.ofSeconds(4))
             .as(StepVerifier::create)
             .verifyComplete();
     }

--- a/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlConnection.java
+++ b/src/test/java/io/r2dbc/postgresql/api/MockPostgresqlConnection.java
@@ -19,8 +19,11 @@ package io.r2dbc.postgresql.api;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.TransactionDefinition;
 import io.r2dbc.spi.ValidationDepth;
+import org.mockito.Mock;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 
 public final class MockPostgresqlConnection implements PostgresqlConnection {
 
@@ -91,6 +94,11 @@ public final class MockPostgresqlConnection implements PostgresqlConnection {
     }
 
     @Override
+    public Mono<Void> lockTimeout(Duration lockTimeout) {
+        return Mono.empty();
+    }
+
+    @Override
     public Mono<Void> releaseSavepoint(String name) {
         return Mono.empty();
     }
@@ -112,6 +120,11 @@ public final class MockPostgresqlConnection implements PostgresqlConnection {
 
     @Override
     public Mono<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> statementTimeout(Duration statementTimeout) {
         return Mono.empty();
     }
 


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.


#### Issue description

Refer #381 
 
#### New Public APIs

This PR adds 2 public APIs to PostgresqlConnectionConfiguration.Builder 
```
statementTimeout(Duration)
lockTimeout(Duration)
```

#### Additional context

As it seems, we need to send statement timeout and lock timeout as part of options in `StartupMessage` 
https://github.com/pgjdbc/pgjdbc/blob/8b6afc0bfe5ac8823f644e599f63c4a06bc2d4b1/docs/documentation/head/connect.md
