### PR TITLE
Replace use of exceptions as control mechanism

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/PostgresqlObjectId.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/PostgresqlObjectId.java
@@ -435,13 +435,13 @@ public enum PostgresqlObjectId implements Type, PostgresTypeIdentifier {
             return oid != null;
         }
 
-        try {
-            valueOf(objectId);
-            return true;
-        } catch (Exception e) {
-            return false;
+        for (PostgresqlObjectId type : values()) {
+            if (type.objectId == objectId) {
+                return true;
+            }
         }
-    }
+        return false;
+   }
 
     /**
      * Returns the {@link PostgresqlObjectId} matching a given object id.


### PR DESCRIPTION
We now look through the list of PostgresqlObjectids to determine if a given objectId is valid - Instead of using the exception-throwing behavior of #valueOf

See [#420](https://github.com/pgjdbc/r2dbc-postgresql/issues/420)