### PR TITLE
 Avoid cast to X509Certificate array during certificate verification

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/client/DefaultHostnameVerifier.java
+++ b/src/main/java/io/r2dbc/postgresql/client/DefaultHostnameVerifier.java
@@ -28,7 +28,6 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 import java.net.IDN;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;

--- a/src/main/java/io/r2dbc/postgresql/client/DefaultHostnameVerifier.java
+++ b/src/main/java/io/r2dbc/postgresql/client/DefaultHostnameVerifier.java
@@ -28,6 +28,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 import java.net.IDN;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public enum DefaultHostnameVerifier implements HostnameVerifier {
             }
         }
 
-        X509Certificate serverCert
+        X509Certificate serverCert;
         try {
             Certificate[] peerCerts = session.getPeerCertificates();
             if (peerCerts == null || peerCerts.length == 0) {

--- a/src/main/java/io/r2dbc/postgresql/client/DefaultHostnameVerifier.java
+++ b/src/main/java/io/r2dbc/postgresql/client/DefaultHostnameVerifier.java
@@ -28,6 +28,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 import java.net.IDN;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -100,7 +101,11 @@ public enum DefaultHostnameVerifier implements HostnameVerifier {
     public boolean verify(String hostname, SSLSession session) {
         X509Certificate[] peerCerts;
         try {
-            peerCerts = (X509Certificate[]) session.getPeerCertificates();
+            Certificate[] currentCerts = session.getPeerCertificates();
+            peerCerts = new X509Certificate[currentCerts.length];
+            for (int i=0;i<currentCerts.length;i++) {
+                peerCerts[i] = (X509Certificate) currentCerts[i];
+            }
         } catch (SSLPeerUnverifiedException e) {
             this.logger.warn("Unable to parse X509Certificate for hostname {}", hostname, e);
             return false;


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request. (No, trivial change)
- [ ] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Hey, so the array cast in the old version fails for us, when we enable `ssl` trough application.yml. I don't know if it ever worked for us before, but here is the related StackOverflow discussion that led us to this fix: https://stackoverflow.com/questions/37248975/error-ljava-lang-object-cannot-be-cast-to-ljava-security-cert-x509certificate
 
 This version do indeed work for us, the array cast is the problem, casting the elements one by one solves it. I did an oldschool for loop, the code can be improved.
 
 
#### New Public APIs

None

#### Additional context

None
