### PR TITLE
Introduce codec mapping caches (0.8.x branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
         <junit.version>5.7.1</junit.version>
         <jmh.version>1.23</jmh.version>
         <mbr.version>0.2.0.RELEASE</mbr.version>
-        <logback.version>1.2.3</logback.version>
-        <mockito.version>3.9.0</mockito.version>
-        <netty.version>4.1.63.Final</netty.version>
-        <postgresql.version>42.2.20</postgresql.version>
+        <logback.version>1.2.5</logback.version>
+        <mockito.version>3.12.4</mockito.version>
+        <netty.version>4.1.66.Final</netty.version>
+        <postgresql.version>42.2.23</postgresql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-spi.version>0.8.5.RELEASE</r2dbc-spi.version>
@@ -210,7 +210,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/jmh/java/io/r2dbc/postgresql/CodecRegistryBenchmarks.java
+++ b/src/jmh/java/io/r2dbc/postgresql/CodecRegistryBenchmarks.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.r2dbc.postgresql.codec.CodecFinderCacheImpl;
+import io.r2dbc.postgresql.codec.CodecFinderDefaultImpl;
+import io.r2dbc.postgresql.codec.Codecs;
+import io.r2dbc.postgresql.codec.DefaultCodecs;
+import io.r2dbc.postgresql.util.ByteBufUtils;
+import org.junit.platform.commons.annotation.Testable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.FLOAT4;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.FLOAT8;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.FLOAT8_ARRAY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2_ARRAY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMP;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+
+/**
+ * Benchmarks for codec encoding and decoding using cached enabled or disabled registries.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Testable
+public class CodecRegistryBenchmarks extends BenchmarkSettings {
+
+    @State(Scope.Benchmark)
+    public static class CodecRegistryHolder {
+
+        @Param({"10", "100", "1000"})
+        public int iterations;
+
+        final ByteBufAllocator byteBufAllocator = new UnpooledByteBufAllocator(false, true);
+
+        DefaultCodecs cacheEnabledRegistry = new DefaultCodecs(byteBufAllocator, false, new CodecFinderCacheImpl());
+
+        DefaultCodecs cacheDisabledRegistry = new DefaultCodecs(byteBufAllocator, false, new CodecFinderDefaultImpl());
+
+    }
+
+    private void decode(Codecs codecs, int iterations, Blackhole voodoo) {
+        for (int i = 0; i < iterations; i++) {
+            voodoo.consume(codecs.decode(
+                TEST.buffer(4).writeInt(200), INT4.getObjectId(), FORMAT_BINARY, Integer.class));
+            voodoo.consume(codecs.decode(
+                ByteBufUtils.encode(TEST, "100"), INT2.getObjectId(), FORMAT_TEXT, Short.class));
+            voodoo.consume(codecs.decode(
+                ByteBufUtils.encode(TEST, "-125.369"), FLOAT8.getObjectId(), FORMAT_TEXT, Double.class));
+            voodoo.consume(codecs.decode(
+                TEST.buffer(4).writeFloat(-65.369f), FLOAT4.getObjectId(), FORMAT_BINARY, Float.class));
+            voodoo.consume(
+                codecs.decode(
+                    ByteBufUtils.encode(TEST, "test"),
+                    VARCHAR.getObjectId(),
+                    FORMAT_TEXT,
+                    String.class));
+            voodoo.consume(
+                codecs.decode(
+                    ByteBufUtils.encode(TEST, "2018-11-04 15:35:00.847108"),
+                    TIMESTAMP.getObjectId(),
+                    FORMAT_TEXT,
+                    LocalDateTime.class));
+            voodoo.consume(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT2_ARRAY.getObjectId(), FORMAT_TEXT, Object.class));
+            voodoo.consume(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT4_ARRAY.getObjectId(), FORMAT_TEXT, Object.class));
+            voodoo.consume(codecs.decode(ByteBufUtils.encode(TEST, "{100.5,200.8}"), FLOAT8_ARRAY.getObjectId(), FORMAT_TEXT, Object.class));
+        }
+    }
+
+    @Benchmark
+    public void decodeWithCacheEnabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        decode(holder.cacheEnabledRegistry, holder.iterations, voodoo);
+    }
+
+    @Benchmark
+    public void decodeWithCacheDisabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        decode(holder.cacheDisabledRegistry, holder.iterations, voodoo);
+    }
+
+    private void encode(Codecs codecs, int iterations, Blackhole voodoo) {
+        for (int i = 0; i < iterations; i++) {
+            voodoo.consume(codecs.encode((short) 12));
+            voodoo.consume(codecs.encode(35698));
+            voodoo.consume(codecs.encode(-256.3698));
+            voodoo.consume(codecs.encode(85.7458f));
+            voodoo.consume(codecs.encode("A text value"));
+            voodoo.consume(codecs.encode(LocalDateTime.now()));
+            voodoo.consume(codecs.encode(new Long[]{100L, 200L}));
+            voodoo.consume(codecs.encode(new Double[]{100.5, 200.25}));
+            voodoo.consume(codecs.encodeNull(Integer.class));
+            voodoo.consume(codecs.encodeNull(String.class));
+            voodoo.consume(codecs.encodeNull(Double[].class));
+        }
+    }
+
+    @Benchmark
+    public void encodeWithCacheEnabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        encode(holder.cacheEnabledRegistry, holder.iterations, voodoo);
+    }
+
+    @Benchmark
+    public void encodeWithCacheDisabledRegistry(CodecRegistryHolder holder, Blackhole voodoo) {
+        encode(holder.cacheDisabledRegistry, holder.iterations, voodoo);
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractBinaryCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractBinaryCodec.java
@@ -26,6 +26,7 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -60,6 +61,11 @@ abstract class AbstractBinaryCodec<T> extends AbstractCodec<T> {
         Assert.requireNonNull(format, "format must not be null");
 
         return BYTEA == type;
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(BYTEA);
     }
 
     byte[] decode(Format format, ByteBuf byteBuf) {

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
@@ -26,9 +26,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.EnumSet;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 
 /**
  * Abstract codec class that provides a basis for all concrete
@@ -93,6 +96,12 @@ abstract class AbstractCodec<T> implements Codec<T> {
     @Override
     public Class<?> type() {
         return this.type;
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        // Unless overridden all codecs supports both text and binary format
+        return EnumSet.of(FORMAT_TEXT, FORMAT_BINARY);
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractGeometryCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractGeometryCodec.java
@@ -25,6 +25,7 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -101,6 +102,11 @@ abstract class AbstractGeometryCodec<T> extends AbstractCodec<T> {
     @Override
     public Parameter encodeNull() {
         return createNull(this.postgresqlObjectId, Format.FORMAT_BINARY);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(this.postgresqlObjectId);
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractJsonCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractJsonCodec.java
@@ -21,11 +21,16 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSON;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSONB;
 
 abstract class AbstractJsonCodec<T> extends AbstractCodec<T> {
+
+    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(JSON, JSONB);
 
     AbstractJsonCodec(Class<T> type) {
         super(type);
@@ -41,7 +46,12 @@ abstract class AbstractJsonCodec<T> extends AbstractCodec<T> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return JSONB == type || JSON == type;
+        return SUPPORTED_TYPES.contains(type);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return SUPPORTED_TYPES;
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
@@ -87,6 +87,10 @@ abstract class AbstractNumericCodec<T extends Number> extends AbstractCodec<T> {
         return potentiallyConvert(number, expectedType, converter);
     }
 
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return SUPPORTED_TYPES;
+    }
     /**
      * Returns the {@link PostgresqlObjectId} for to identify whether this codec is the default codec.
      *

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractTemporalCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractTemporalCodec.java
@@ -158,4 +158,9 @@ abstract class AbstractTemporalCodec<T extends Temporal> extends AbstractCodec<T
         return expectedType.isInstance(temporal) ? expectedType.cast(temporal) : converter.apply(temporal);
     }
 
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return SUPPORTED_TYPES;
+    }
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/BigDecimalArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BigDecimalArrayCodec.java
@@ -24,6 +24,7 @@ import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 final class BigDecimalArrayCodec extends AbstractArrayCodec<BigDecimal> {
@@ -35,6 +36,11 @@ final class BigDecimalArrayCodec extends AbstractArrayCodec<BigDecimal> {
     @Override
     public Parameter encodeNull() {
         return createNull(PostgresqlObjectId.NUMERIC_ARRAY, Format.FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(PostgresqlObjectId.NUMERIC_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/BlobCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BlobCodec.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.BYTEA;
@@ -73,6 +74,11 @@ final class BlobCodec extends AbstractCodec<Blob> {
                 .concatWith(Flux.from(value.discard())
                     .then(Mono.empty()))
         );
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(BYTEA);
     }
 
     private static final class ByteABlob implements Blob {

--- a/src/main/java/io/r2dbc/postgresql/codec/BooleanArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BooleanArrayCodec.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -40,6 +41,11 @@ final class BooleanArrayCodec extends AbstractArrayCodec<Boolean> {
     @Override
     public Parameter encodeNull() {
         return createNull(BOOL_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(BOOL_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/BooleanCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BooleanCodec.java
@@ -25,6 +25,8 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
+import java.util.Collections;
+
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.BOOL;
 
@@ -40,6 +42,11 @@ final class BooleanCodec extends AbstractCodec<Boolean> {
     @Override
     public Parameter encodeNull() {
         return createNull(BOOL, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(BOOL);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ByteCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ByteCodec.java
@@ -62,4 +62,14 @@ final class ByteCodec extends AbstractCodec<Byte> {
         return this.delegate.doEncode((short) value);
     }
 
+    @Override
+    public Iterable<Format> getFormats() {
+        return this.delegate.getFormats();
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/CharacterCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CharacterCodec.java
@@ -62,4 +62,14 @@ final class CharacterCodec extends AbstractCodec<Character> {
         return this.delegate.doEncode(value.toString());
     }
 
+    @Override
+    public Iterable<Format> getFormats() {
+        return this.delegate.getFormats();
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/ClobCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ClobCodec.java
@@ -28,6 +28,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
 
+import java.util.Arrays;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
@@ -72,6 +75,16 @@ final class ClobCodec extends AbstractCodec<Clob> {
                 .concatWith(Flux.from(value.discard())
                     .then(Mono.empty()))
         );
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Arrays.asList(VARCHAR, TEXT);
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        return Arrays.asList(FORMAT_TEXT, FORMAT_BINARY);
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/Codec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/Codec.java
@@ -95,4 +95,18 @@ public interface Codec<T> {
      */
     Class<?> type();
 
+    /**
+     * Returns the collection of {@link Format} supported by this codec
+     *
+     * @return the formats
+     */
+    Iterable<Format> getFormats();
+
+    /**
+     * Returns the collection of {@link PostgresqlObjectId} this codec can handle
+     *
+     * @return the datatypes
+     */
+    Iterable<PostgresqlObjectId> getDataTypes();
+
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/CodecFinder.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CodecFinder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.message.Format;
+import reactor.util.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * Helper used to find a {@link Codec} for encoding or decoding actions from a provided list of codecs.
+ */
+public interface CodecFinder {
+
+    void updateCodecs(List<Codec<?>> codecs);
+
+    @Nullable
+    <T> Codec<T> findDecodeCodec(int dataType, Format format, Class<? extends T> type);
+
+    @Nullable
+    <T> Codec<T> findEncodeCodec(T value);
+
+    @Nullable
+    <T> Codec<T> findEncodeNullCodec(Class<T> type);
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/CodecFinderCacheImpl.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CodecFinderCacheImpl.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
+import io.r2dbc.postgresql.util.Assert;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Cache implementation of the {@link CodecFinder}. This will keep the relevant {@link Codec} for the type, format and database type cached for faster access.
+ * In case the {@link Codec} can't be found in the cache, a fallback search using {@link CodecFinderDefaultImpl} will be done.
+ */
+public class CodecFinderCacheImpl implements CodecFinder {
+
+    private static final Logger LOG = Loggers.getLogger(CodecFinderCacheImpl.class);
+
+    List<Codec<?>> codecs = Collections.emptyList();
+
+    private final Map<Integer, Codec<?>> decodeCodecsCache = new ConcurrentHashMap<>();
+
+    private final Map<Integer, Codec<?>> encodeCodecsCache = new ConcurrentHashMap<>();
+
+    private final Map<Integer, Codec<?>> encodeNullCodecsCache = new ConcurrentHashMap<>();
+
+    private final CodecFinder fallBackFinder;
+
+    public CodecFinderCacheImpl() {
+        this(new CodecFinderDefaultImpl());
+    }
+
+    public CodecFinderCacheImpl(CodecFinder fallBackFinder) {
+        Assert.isTrue(!(fallBackFinder instanceof CodecFinderCacheImpl), "fallBackFinder must not be of type CodecFinderCacheImpl");
+        this.fallBackFinder = fallBackFinder;
+    }
+
+    private static <T> int generateCodecHash(int dataType, Format format, Class<? extends T> type) {
+        int hash = (dataType << 5) - dataType;
+        hash = (hash << 5) - hash + format.hashCode();
+        hash = (hash << 5) - hash + generateCodecHash(type);
+        return hash;
+    }
+
+    private static <T> int generateCodecHash(Class<? extends T> type) {
+        int hash = type.hashCode();
+        if (type.getComponentType() != null) {
+            hash = (hash << 5) - hash + generateCodecHash(type.getComponentType());
+        }
+        return hash;
+    }
+
+    void invalidateCaches() {
+        this.decodeCodecsCache.clear();
+        this.encodeCodecsCache.clear();
+        this.encodeNullCodecsCache.clear();
+        buildCaches();
+    }
+
+    void buildCaches() {
+        for (Codec<?> c : this.codecs) {
+            cacheEncode(c, c.type());
+            for (PostgresqlObjectId identifier : c.getDataTypes()) {
+                for (Format format : c.getFormats()) {
+                    cacheDecode(c, c.type(), identifier, format);
+                }
+            }
+        }
+        // Handle decode to Object.class support
+        for (PostgresqlObjectId identifier : PostgresqlObjectId.values()) {
+            for (Format format : Format.all()) {
+                Codec<?> c = fallBackFinder.findDecodeCodec(identifier.getObjectId(), format, Object.class);
+                if (c != null) {
+                    cacheDecode(c, Object.class, identifier, format);
+                }
+            }
+        }
+    }
+
+    private void cacheDecode(Codec<?> c, Class<?> type, PostgresqlObjectId identifier, Format format) {
+        int decodeHash = generateCodecHash(identifier.getObjectId(), format, type);
+        decodeCodecsCache.putIfAbsent(decodeHash, c);
+    }
+
+    private void cacheEncode(Codec<?> c, Class<?> type) {
+        int encodeHash = generateCodecHash(type);
+        encodeCodecsCache.putIfAbsent(encodeHash, c);
+        if (c.canEncodeNull(type)) {
+            encodeNullCodecsCache.putIfAbsent(encodeHash, c);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    synchronized <T> Codec<T> findCodec(int codecHash, Map<Integer, Codec<?>> cache, Supplier<Codec<T>> fallback) {
+        return Optional.ofNullable((Codec<T>) cache.get(codecHash)).orElseGet(fallback);
+    }
+
+    @Override
+    public synchronized void updateCodecs(List<Codec<?>> codecs) {
+        this.codecs = codecs;
+        fallBackFinder.updateCodecs(codecs);
+        invalidateCaches();
+    }
+
+    @Override
+    public <T> Codec<T> findDecodeCodec(int dataType, Format format, Class<? extends T> type) {
+        int hash = generateCodecHash(dataType, format, type);
+        return findCodec(hash, decodeCodecsCache, () -> {
+            LOG.trace("[codec-finder dataType={}, format={}, type={}] Decode codec not found in cache", dataType, format, type.getName());
+            Codec<T> c = fallBackFinder.findDecodeCodec(dataType, format, type);
+            if (c != null) {
+                decodeCodecsCache.putIfAbsent(hash, c);
+            }
+            return c;
+        });
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeCodec(T value) {
+        int hash = generateCodecHash(value.getClass());
+        return findCodec(hash, encodeCodecsCache, () -> {
+            LOG.trace("[codec-finder type={}] Encode codec not found in cache", value.getClass().getName());
+            Codec<T> c = fallBackFinder.findEncodeCodec(value);
+            if (c != null) {
+                encodeCodecsCache.putIfAbsent(hash, c);
+            }
+            return c;
+        });
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeNullCodec(Class<T> type) {
+        int hash = generateCodecHash(type);
+        return findCodec(hash, encodeNullCodecsCache, () -> {
+            LOG.trace("[codec-finder type={}] Encode null codec not found in cache", type.getName());
+            Codec<T> c = fallBackFinder.findEncodeNullCodec(type);
+            if (c != null) {
+                encodeNullCodecsCache.putIfAbsent(hash, c);
+            }
+            return c;
+        });
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImpl.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.message.Format;
+import reactor.util.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Default implementation of the {@link CodecFinder}. This will systematically search for {@link Codec} for the type, format and database type
+ * by calling the methods {@link Codec#canDecode}, {@link Codec#canEncode} and {@link Codec#canEncodeNull} on each registered codecs.
+ */
+public class CodecFinderDefaultImpl implements CodecFinder {
+
+    List<Codec<?>> codecs = Collections.emptyList();
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    synchronized <T> Codec<T> findCodec(Predicate<Codec<?>> predicate) {
+        for (Codec<?> codec : codecs) {
+            if (predicate.test(codec)) {
+                return (Codec<T>) codec;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized void updateCodecs(List<Codec<?>> codecs) {
+        this.codecs = codecs;
+    }
+
+    @Override
+    public <T> Codec<T> findDecodeCodec(int dataType, Format format, Class<? extends T> type) {
+        return findCodec(codec -> codec.canDecode(dataType, format, type));
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeCodec(T value) {
+        return findCodec(codec -> codec.canEncode(value));
+    }
+
+    @Override
+    public <T> Codec<T> findEncodeNullCodec(Class<T> type) {
+        return findCodec(codec -> codec.canEncodeNull(type));
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/DateCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DateCodec.java
@@ -45,6 +45,11 @@ final class DateCodec extends AbstractCodec<Date> {
     }
 
     @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
+    @Override
     boolean doCanDecode(PostgresqlObjectId type, Format format) {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");

--- a/src/main/java/io/r2dbc/postgresql/codec/DoubleArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DoubleArrayCodec.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -40,6 +41,11 @@ final class DoubleArrayCodec extends AbstractArrayCodec<Double> {
     @Override
     public Parameter encodeNull() {
         return createNull(FLOAT8_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(FLOAT8_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/EnumCodec.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.extension.CodecRegistrar;
 import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.core.publisher.Mono;
@@ -29,11 +30,14 @@ import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 
 /**
@@ -103,6 +107,16 @@ public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
     @Override
     public Class<?> type() {
         return this.type;
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        return EnumSet.of(FORMAT_TEXT, FORMAT_BINARY);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return PostgresqlObjectId.isValid(oid) ? Collections.singleton(PostgresqlObjectId.valueOf(oid)) : Collections.emptyList();
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/FloatArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/FloatArrayCodec.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -40,6 +41,11 @@ final class FloatArrayCodec extends AbstractArrayCodec<Float> {
     @Override
     public Parameter encodeNull() {
         return createNull(FLOAT4_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(FLOAT4_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/InetAddressCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/InetAddressCodec.java
@@ -27,6 +27,7 @@ import reactor.util.annotation.Nullable;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Collections;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INET;
@@ -43,6 +44,11 @@ final class InetAddressCodec extends AbstractCodec<InetAddress> {
     @Override
     public Parameter encodeNull() {
         return createNull(INET, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(INET);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/IntegerArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/IntegerArrayCodec.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -37,6 +38,11 @@ final class IntegerArrayCodec extends AbstractArrayCodec<Integer> {
     @Override
     public Parameter encodeNull() {
         return createNull(INT4_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(INT4_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/IntervalCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/IntervalCodec.java
@@ -24,6 +24,9 @@ import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
+import java.util.Collections;
+import java.util.EnumSet;
+
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INTERVAL;
 
@@ -47,6 +50,16 @@ final class IntervalCodec extends AbstractCodec<Interval> {
     @Override
     Interval doDecode(ByteBuf buffer, PostgresqlObjectId dataType, Format format, Class<? extends Interval> type) {
         return Interval.parse(ByteBufUtils.decode(buffer));
+    }
+
+    @Override
+    public Iterable<Format> getFormats() {
+        return EnumSet.of(FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(INTERVAL);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LongArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LongArrayCodec.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -37,6 +38,11 @@ final class LongArrayCodec extends AbstractArrayCodec<Long> {
     @Override
     public Parameter encodeNull() {
         return createNull(INT8_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(INT8_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ShortArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ShortArrayCodec.java
@@ -24,6 +24,7 @@ import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import reactor.util.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -38,6 +39,11 @@ final class ShortArrayCodec extends AbstractArrayCodec<Short> {
     @Override
     public Parameter encodeNull() {
         return createNull(INT2_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(INT2_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/StringArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringArrayCodec.java
@@ -24,6 +24,8 @@ import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -35,6 +37,8 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR_ARRAY;
 
 final class StringArrayCodec extends AbstractArrayCodec<String> {
 
+    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(BPCHAR_ARRAY, CHAR_ARRAY, NAME_ARRAY, TEXT_ARRAY, VARCHAR_ARRAY);
+
     StringArrayCodec(ByteBufAllocator byteBufAllocator) {
         super(byteBufAllocator, String.class);
     }
@@ -42,6 +46,11 @@ final class StringArrayCodec extends AbstractArrayCodec<String> {
     @Override
     public Parameter encodeNull() {
         return createNull(TEXT_ARRAY, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return SUPPORTED_TYPES;
     }
 
     @Override
@@ -59,7 +68,7 @@ final class StringArrayCodec extends AbstractArrayCodec<String> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return (BPCHAR_ARRAY == type || CHAR_ARRAY == type || TEXT_ARRAY == type || VARCHAR_ARRAY == type | NAME_ARRAY == type);
+        return SUPPORTED_TYPES.contains(type);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
@@ -25,6 +25,9 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.BPCHAR;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.CHAR;
@@ -34,6 +37,8 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
 
 final class StringCodec extends AbstractCodec<String> {
+
+    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(BPCHAR, CHAR, TEXT, UNKNOWN, VARCHAR, NAME);
 
     private final ByteBufAllocator byteBufAllocator;
 
@@ -52,7 +57,7 @@ final class StringCodec extends AbstractCodec<String> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return BPCHAR == type || CHAR == type || TEXT == type || UNKNOWN == type || VARCHAR == type || NAME == type;
+        return SUPPORTED_TYPES.contains(type);
     }
 
     @Override
@@ -67,6 +72,11 @@ final class StringCodec extends AbstractCodec<String> {
         Assert.requireNonNull(value, "value must not be null");
 
         return create(VARCHAR, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value));
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return SUPPORTED_TYPES;
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/UriCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/UriCodec.java
@@ -43,6 +43,11 @@ final class UriCodec extends AbstractCodec<URI> {
     }
 
     @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
+    @Override
     boolean doCanDecode(PostgresqlObjectId type, Format format) {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");

--- a/src/main/java/io/r2dbc/postgresql/codec/UrlCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/UrlCodec.java
@@ -51,6 +51,11 @@ final class UrlCodec extends AbstractCodec<URL> {
     }
 
     @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
+    @Override
     boolean doCanDecode(PostgresqlObjectId type, Format format) {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");

--- a/src/main/java/io/r2dbc/postgresql/codec/UuidArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/UuidArrayCodec.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 
+import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -38,6 +39,11 @@ final class UuidArrayCodec extends AbstractArrayCodec<UUID> {
     @Override
     public Parameter encodeNull() {
         return createNull(PostgresqlObjectId.UUID_ARRAY, Format.FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(PostgresqlObjectId.UUID_ARRAY);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/UuidCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/UuidCodec.java
@@ -25,6 +25,7 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
@@ -49,6 +50,11 @@ final class UuidCodec extends AbstractCodec<UUID> {
     @Override
     public Parameter encodeNull() {
         return createNull(PostgresqlObjectId.UUID, FORMAT_TEXT);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return Collections.singleton(PostgresqlObjectId.UUID);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ZoneIdCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ZoneIdCodec.java
@@ -43,6 +43,11 @@ final class ZoneIdCodec extends AbstractCodec<ZoneId> {
     }
 
     @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return this.delegate.getDataTypes();
+    }
+
+    @Override
     boolean doCanDecode(PostgresqlObjectId type, Format format) {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");

--- a/src/main/resources/META-INF/services/io.r2dbc.postgresql.codec.CodecFinder
+++ b/src/main/resources/META-INF/services/io.r2dbc.postgresql.codec.CodecFinder
@@ -1,0 +1,1 @@
+io.r2dbc.postgresql.codec.CodecFinderCacheImpl

--- a/src/test/java/io/r2dbc/postgresql/CodecExtensionIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/CodecExtensionIntegrationTests.java
@@ -33,6 +33,9 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.Collections;
+import java.util.EnumSet;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -136,6 +139,16 @@ final class CodecExtensionIntegrationTests extends AbstractIntegrationTests {
         @Override
         public Class<?> type() {
             return Json.class;
+        }
+
+        @Override
+        public Iterable<Format> getFormats() {
+            return EnumSet.of(Format.FORMAT_TEXT, Format.FORMAT_BINARY);
+        }
+
+        @Override
+        public Iterable<PostgresqlObjectId> getDataTypes() {
+            return Collections.singleton(PostgresqlObjectId.JSON);
         }
     }
 

--- a/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientIntegrationTests.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.util.ReflectionUtils;
 import reactor.core.publisher.EmitterProcessor;
@@ -311,6 +313,7 @@ final class ReactorNettyClientIntegrationTests {
     }
 
     @Test
+    @DisabledOnOs({OS.MAC, OS.WINDOWS})
     void unixDomainSocketTest() {
 
         String socket = "/tmp/.s.PGSQL.5432";

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecFinderCacheImplUnitTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecFinderCacheImplUnitTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.FLOAT8;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@ExtendWith(MockitoExtension.class)
+class CodecFinderCacheImplUnitTest {
+
+    DefaultCodecs codecs;
+
+    CodecFinderCacheImpl codecFinder;
+
+    @Spy
+    CodecFinderDefaultImpl fallBackFinder = new CodecFinderDefaultImpl();
+
+    @Captor
+    ArgumentCaptor<Map<Integer, Codec<?>>> cacheArgumentCaptor;
+
+    @Mock
+    Codec<String> stringCodec;
+
+    @Mock
+    Codec<Integer> integerCodec;
+
+    @BeforeEach
+    void setUp() {
+        codecFinder = new CodecFinderCacheImpl(fallBackFinder);
+        // We use the DefaultCodecs to populate the cache with some codecs
+        codecs = new DefaultCodecs(TEST, false, codecFinder);
+    }
+
+    @Test
+    void fallbackFinder_same_class() {
+        assertThatThrownBy(() -> new CodecFinderCacheImpl(codecFinder)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void findCodec() {
+        List<Codec<?>> codecList = Arrays.asList(stringCodec, integerCodec);
+        doReturn(String.class).when(stringCodec).type();
+        doReturn(Collections.singleton(VARCHAR)).when(stringCodec).getDataTypes();
+        doReturn(EnumSet.of(FORMAT_TEXT)).when(stringCodec).getFormats();
+        doReturn(Integer.class).when(integerCodec).type();
+        doReturn(Collections.singleton(INT4)).when(integerCodec).getDataTypes();
+        doReturn(EnumSet.of(FORMAT_TEXT)).when(integerCodec).getFormats();
+        codecFinder.updateCodecs(codecList);
+        assertThat(codecFinder.findDecodeCodec(INT4.getObjectId(), FORMAT_TEXT, Integer.class)).isEqualTo(integerCodec);
+        assertThat(codecFinder.findDecodeCodec(VARCHAR.getObjectId(), FORMAT_TEXT, String.class)).isEqualTo(stringCodec);
+        assertThat(codecFinder.findDecodeCodec(FLOAT8.getObjectId(), FORMAT_TEXT, Double.class)).isNull();
+    }
+
+    @Test
+    void findDecodeCodecShort() {
+        CodecFinderCacheImpl spyCodecs = spy(codecFinder);
+        Codec<Short> shortCodec = spyCodecs.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, Short.class);
+        assertThat(shortCodec).isNotNull();
+    }
+
+    @Test
+    void findDecodeCodecNotFound() {
+        assertThat(codecFinder.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, DefaultCodecsUnitTests.class)).isNull();
+    }
+
+    @Test
+    void findEncodeCodecDouble() {
+        CodecFinderCacheImpl spyCodecs = spy(codecFinder);
+        Codec<?> doubleCodec = spyCodecs.findEncodeCodec(1.2);
+        assertThat(doubleCodec).isInstanceOf(DoubleCodec.class);
+    }
+
+    @Test
+    void findEncodeCodecNotFound() {
+        assertThat(codecFinder.findEncodeCodec(this)).isNull();
+    }
+
+    @Test
+    void findEncodeNullCodecInteger() {
+        CodecFinderCacheImpl spyCodecs = spy(codecFinder);
+        Codec<?> intCodec = spyCodecs.findEncodeNullCodec(Integer.class);
+        assertThat(intCodec).isInstanceOf(IntegerCodec.class);
+    }
+
+    @Test
+    void findEncodeNullCodecNotFound() {
+        assertThat(codecFinder.findEncodeNullCodec(DefaultCodecsUnitTests.class)).isNull();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImplUnitTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecFinderDefaultImplUnitTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CodecFinderDefaultImplUnitTest {
+
+    DefaultCodecs codecs;
+
+    @Spy
+    CodecFinderDefaultImpl codecFinder = new CodecFinderDefaultImpl();
+
+    @Captor
+    ArgumentCaptor<Predicate<Codec<?>>> predicateArgumentCaptor;
+
+    @Mock
+    Codec<String> stringCodec;
+
+    @Mock
+    Codec<Integer> integerCodec;
+
+    @BeforeEach
+    void setUp() {
+        // We use the DefaultCodecs to populate the cache with some codecs
+        codecs = new DefaultCodecs(TEST, false, codecFinder);
+    }
+
+    @Test
+    void findCodec_notFound() {
+        List<Codec<?>> codecList = Arrays.asList(stringCodec, integerCodec);
+        codecFinder.updateCodecs(codecList);
+        doReturn(false).when(stringCodec).canEncode(this);
+        doReturn(false).when(integerCodec).canEncode(this);
+        assertThat(codecFinder.findCodec(c -> c.canEncode(this))).isNull();
+    }
+
+    @Test
+    void findCodec_found() {
+        List<Codec<?>> codecList = Arrays.asList(stringCodec, integerCodec);
+        codecFinder.updateCodecs(codecList);
+        doReturn(false).when(stringCodec).canEncode(this);
+        doReturn(true).when(integerCodec).canEncode(this);
+        assertThat(codecFinder.findCodec(c -> c.canEncode(this))).isEqualTo(integerCodec);
+    }
+
+    @Test
+    void findDecodeCodecShort() {
+        Codec<Short> shortCodec = codecFinder.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, Short.class);
+        assertThat(shortCodec).isNotNull();
+        verify(codecFinder).findCodec(predicateArgumentCaptor.capture());
+    }
+
+    @Test
+    void findDecodeCodecNotFound() {
+        assertThat(codecFinder.findDecodeCodec(INT2.getObjectId(), FORMAT_TEXT, this.getClass())).isNull();
+    }
+
+    @Test
+    void findEncodeCodecDouble() {
+        Codec<?> doubleCodec = codecFinder.findEncodeCodec(1.2);
+        assertThat(doubleCodec).isInstanceOf(DoubleCodec.class);
+        verify(codecFinder).findCodec(predicateArgumentCaptor.capture());
+    }
+
+    @Test
+    void findEncodeCodecNotFound() {
+        assertThat(codecFinder.findEncodeCodec(this)).isNull();
+    }
+
+    @Test
+    void findEncodeNullCodecInteger() {
+        Codec<?> intCodec = codecFinder.findEncodeNullCodec(Integer.class);
+        assertThat(intCodec).isInstanceOf(IntegerCodec.class);
+        verify(codecFinder).findCodec(predicateArgumentCaptor.capture());
+    }
+
+    @Test
+    void findEncodeNullCodecNotFound() {
+        assertThat(codecFinder.findEncodeNullCodec(DefaultCodecsUnitTests.class)).isNull();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsUnitTests.java
@@ -16,24 +16,33 @@
 
 package io.r2dbc.postgresql.codec;
 
-import io.netty.buffer.ByteBuf;
+import io.r2dbc.postgresql.client.Binding;
 import io.r2dbc.postgresql.client.Parameter;
-import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.util.ByteBufUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.EnumSet;
 
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
 import static io.r2dbc.postgresql.client.ParameterAssert.assertThat;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.FLOAT8;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2_ARRAY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT8_ARRAY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMP;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMPTZ;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
@@ -41,58 +50,75 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR_ARRAY;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
 
 /**
  * Unit tests for {@link DefaultCodecs}.
  */
+@ExtendWith(MockitoExtension.class)
 final class DefaultCodecsUnitTests {
+
+    DefaultCodecs codecs;
+
+    @Mock
+    Codec<String> dummyCodec;
+
+    // We test with the cache version of the CodecFinder. We could switch the implementation if needed.
+    CodecFinder codecFinder = new CodecFinderCacheImpl();
+
+    @BeforeEach
+    void before() {
+        codecs = new DefaultCodecs(TEST, false, codecFinder);
+        lenient().doReturn(String.class).when(dummyCodec).type();
+        lenient().doReturn(EnumSet.of(FORMAT_TEXT, FORMAT_BINARY)).when(dummyCodec).getFormats();
+        lenient().doReturn(Collections.singleton(TEXT)).when(dummyCodec).getDataTypes();
+    }
 
     @Test
     void constructorNoByteBufAllocator() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(null, true, codecFinder))
             .withMessage("byteBufAllocator must not be null");
     }
 
     @Test
     void decode() {
-        assertThat(new DefaultCodecs(TEST).decode(TEST.buffer(4).writeInt(100), INT4.getObjectId(), FORMAT_BINARY, Integer.class))
+        assertThat(codecs.decode(TEST.buffer(4).writeInt(100), INT4.getObjectId(), FORMAT_BINARY, Integer.class))
             .isEqualTo(100);
     }
 
     @Test
     void decodeDefaultType() {
-        assertThat(new DefaultCodecs(TEST).decode(TEST.buffer(4).writeInt(100), INT4.getObjectId(), FORMAT_BINARY, Object.class))
+        assertThat(codecs.decode(TEST.buffer(4).writeInt(100), INT4.getObjectId(), FORMAT_BINARY, Object.class))
             .isEqualTo(100);
     }
 
     @Test
     void decodeNoFormat() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).decode(TEST.buffer(4), INT4.getObjectId(), null, Object.class))
+        assertThatIllegalArgumentException().isThrownBy(() -> codecs.decode(TEST.buffer(4), INT4.getObjectId(), null, Object.class))
             .withMessage("format must not be null");
     }
 
     @Test
     void decodeNoType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).decode(TEST.buffer(4), INT4.getObjectId(), FORMAT_BINARY, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> codecs.decode(TEST.buffer(4), INT4.getObjectId(), FORMAT_BINARY, null))
             .withMessage("type must not be null");
     }
 
     @Test
     void decodeNull() {
-        assertThat(new DefaultCodecs(TEST).decode(null, INT4.getObjectId(), FORMAT_BINARY, Integer.class))
+        assertThat(codecs.decode(null, INT4.getObjectId(), FORMAT_BINARY, Integer.class))
             .isNull();
     }
 
     @Test
     void decodeUnsupportedType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).decode(TEST.buffer(4), INT4.getObjectId(), FORMAT_BINARY, Void.class))
+        assertThatIllegalArgumentException().isThrownBy(() -> codecs.decode(TEST.buffer(4), INT4.getObjectId(), FORMAT_BINARY, Void.class))
             .withMessage("Cannot decode value of type java.lang.Void with OID 23");
     }
 
     @Test
     void delegatePriority() {
-        Codecs codecs = new DefaultCodecs(TEST);
-
         assertThat(codecs.decode(TEST.buffer(2).writeShort((byte) 100), INT2.getObjectId(), FORMAT_BINARY, Object.class)).isInstanceOf(Short.class);
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "100"), INT2.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(Short.class);
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "test"), VARCHAR.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(String.class);
@@ -106,7 +132,7 @@ final class DefaultCodecsUnitTests {
 
     @Test
     void encode() {
-        Parameter parameter = new DefaultCodecs(TEST).encode(100);
+        Parameter parameter = codecs.encode(100);
 
         assertThat(parameter)
             .hasFormat(FORMAT_BINARY)
@@ -116,75 +142,60 @@ final class DefaultCodecsUnitTests {
 
     @Test
     void encodeNoValue() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).encode(null))
+        assertThatIllegalArgumentException().isThrownBy(() -> codecs.encode(null))
             .withMessage("value must not be null");
     }
 
     @Test
     void encodeNull() {
-        Parameter parameter = new DefaultCodecs(TEST).encodeNull(Integer.class);
+        Parameter parameter = codecs.encodeNull(Integer.class);
 
         assertThat(parameter).isEqualTo(new Parameter(FORMAT_BINARY, INT4.getObjectId(), NULL_VALUE));
     }
 
     @Test
     void encodeNullNoType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).encodeNull(null))
+        assertThatIllegalArgumentException().isThrownBy(() -> codecs.encodeNull(null))
             .withMessage("type must not be null");
     }
 
     @Test
     void addCodecFirst() {
-        DefaultCodecs codecs = new DefaultCodecs(TEST);
-        codecs.addFirst(DummyCodec.INSTANCE);
-        assertThat(codecs).startsWith(DummyCodec.INSTANCE);
+        DefaultCodecs spyCodecs = spy(codecs);
+        Codec<?> stringCodec = codecFinder.findEncodeCodec("string");
+        lenient().when(dummyCodec.canEncode("string")).thenReturn(true);
+        spyCodecs.addFirst(dummyCodec);
+        assertThat(spyCodecs).startsWith(dummyCodec);
+        Codec<?> overriddenStringCodec = codecFinder.findEncodeCodec("string");
+        assertThat(overriddenStringCodec).isNotEqualTo(stringCodec).isEqualTo(dummyCodec);
     }
 
     @Test
     void addCodecLast() {
-        DefaultCodecs codecs = new DefaultCodecs(TEST);
-        codecs.addLast(DummyCodec.INSTANCE);
-        assertThat(codecs).endsWith(DummyCodec.INSTANCE);
+        DefaultCodecs spyCodecs = spy(codecs);
+        spyCodecs.addLast(dummyCodec);
+        assertThat(spyCodecs).endsWith(dummyCodec);
     }
 
-    enum DummyCodec implements Codec<Object> {
-
-        INSTANCE;
-
-        @Override
-        public boolean canDecode(int dataType, Format format, Class<?> type) {
-            return false;
-        }
-
-        @Override
-        public boolean canEncode(Object value) {
-            return false;
-        }
-
-        @Override
-        public boolean canEncodeNull(Class<?> type) {
-            return false;
-        }
-
-        @Override
-        public Parameter encode(Object value) {
-            return null;
-        }
-
-        @Override
-        public Parameter encodeNull() {
-            return null;
-        }
-
-        @Override
-        public Class<?> type() {
-            return null;
-        }
-
-        @Override
-        public Object decode(ByteBuf buffer, int dataType, Format format, Class<?> type) {
-            return null;
-        }
+    @Test
+    void testEncodeDecode() {
+        Flux.fromIterable((new Binding(1)).add(0, codecs.encode(65.589)).getParameterValues())
+            .flatMap(Flux::from)
+            .subscribe(bb -> {
+                assertThat(codecs.decode(bb, FLOAT8.getObjectId(), FORMAT_BINARY, Double.class)).isEqualTo(65.589);
+            });
+        StepVerifier.create(Flux.fromIterable((new Binding(2))
+                    .add(0, codecs.encode(65.589))
+                    .add(1, codecs.encode((short) 15))
+                    .getParameterValues())
+                .flatMap(Flux::from))
+            .assertNext(byteBuf -> {
+                assertThat(codecs.decode(byteBuf, FLOAT8.getObjectId(), FORMAT_BINARY, Double.class)).isEqualTo(65.589);
+            })
+            .assertNext(byteBuf -> {
+                assertThat(codecs.decode(byteBuf, INT2.getObjectId(), FORMAT_BINARY, Short.class)).isEqualTo((short) 15);
+            })
+            .verifyComplete();
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/codec/MockCodec.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/MockCodec.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Mock imoplementation of {@link Codec}.
@@ -60,6 +61,11 @@ public final class MockCodec<T> extends AbstractCodec<T> {
     @Override
     public Parameter encodeNull() {
         return this.encodings.get(null);
+    }
+
+    @Override
+    public Iterable<PostgresqlObjectId> getDataTypes() {
+        return canDecodes.stream().map(cd -> cd.type).collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
 Introduce codec mapping caches to improve encoding and decoding performances.

* Refactored the codec registry to use a `CodecFinder` (default to SPI definition in the classpath)
* Switched the codec list to a thread safe variant to avoid the synchronized blocks. Even though `CopyOnWriteArrayList` is not super performant it should work fine in this context where the list should not be frequently updated.
* Provided 2 implementations of the codec finder, one without cache and another with cache
* Added a build cache method that will attempt to fill the cache when the codecs are updated. This cannot covers all the cases like the nested arrays, therefore for those type the cache will be filled dynamically on per-request basis
* Added microbenchmarks for codec encode and decode using the cache based implementation or not
* Switched `mockito-core` to `mockito-junit-jupiter` for Junit 5 support
* Disabled unixDomainSocketTest IT when running on Mac or Windows

JMH results: 
```
Benchmark                                                (iterations)  (resultSize)   Mode  Cnt       Score      Error  Units
CodecRegistryBenchmarks.decodeWithCacheDisabledRegistry            10           N/A  thrpt    5   13456.082 ±  851.123  ops/s
CodecRegistryBenchmarks.decodeWithCacheDisabledRegistry           100           N/A  thrpt    5    1528.566 ±   35.987  ops/s
CodecRegistryBenchmarks.decodeWithCacheDisabledRegistry          1000           N/A  thrpt    5     152.652 ±    1.207  ops/s
CodecRegistryBenchmarks.decodeWithCacheEnabledRegistry             10           N/A  thrpt    5   27485.494 ±  302.008  ops/s
CodecRegistryBenchmarks.decodeWithCacheEnabledRegistry            100           N/A  thrpt    5    2821.798 ±    8.432  ops/s
CodecRegistryBenchmarks.decodeWithCacheEnabledRegistry           1000           N/A  thrpt    5     272.775 ±    0.643  ops/s
CodecRegistryBenchmarks.encodeWithCacheDisabledRegistry            10           N/A  thrpt    5   43370.774 ±  273.390  ops/s
CodecRegistryBenchmarks.encodeWithCacheDisabledRegistry           100           N/A  thrpt    5    4416.795 ±   72.559  ops/s
CodecRegistryBenchmarks.encodeWithCacheDisabledRegistry          1000           N/A  thrpt    5     430.082 ±    2.369  ops/s
CodecRegistryBenchmarks.encodeWithCacheEnabledRegistry             10           N/A  thrpt    5  193702.669 ± 2121.691  ops/s
CodecRegistryBenchmarks.encodeWithCacheEnabledRegistry            100           N/A  thrpt    5   19407.580 ±  179.642  ops/s
CodecRegistryBenchmarks.encodeWithCacheEnabledRegistry           1000           N/A  thrpt    5    1914.948 ±   12.990  ops/s
```

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

See gh-409
<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
