### PR TITLE
Consider disabled SSL flag in `ConnectionFactoryOptions`

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -287,7 +287,12 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
 
     private static void setupSsl(PostgresqlConnectionConfiguration.Builder builder, OptionMapper mapper) {
 
-        mapper.from(SSL).to(builder::enableSsl);
+        mapper.from(SSL).map(OptionMapper::toBoolean).to(enableSsl -> {
+            if(enableSsl) {
+                builder.enableSsl();
+            }
+        });
+
         mapper.from(SSL_MODE).map(it -> {
 
             if (it instanceof String) {

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderUnitTests.java
@@ -149,7 +149,22 @@ final class PostgresqlConnectionFactoryProviderUnitTests {
     }
 
     @Test
-    void supportsSsl() {
+    void disableSsl() {
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+            .option(DRIVER, POSTGRESQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(SSL, false)
+            .build());
+
+        SSLConfig sslConfig = factory.getConfiguration().getSslConfig();
+
+        assertThat(sslConfig.getSslMode()).isEqualTo(SSLMode.DISABLE);
+    }
+
+    @Test
+    void enableSsl() {
         PostgresqlConnectionFactory factory = this.provider.create(builder()
             .option(DRIVER, POSTGRESQL_DRIVER)
             .option(HOST, "test-host")


### PR DESCRIPTION

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.


#### Issue description
In the existing logic, we are setting `SSLMode` to VERIFY_FULL when the SSL option is added by the user. As part of this PR adding a check to ensure that SSL flag is set as `true`. 

 see #453 