### PR TITLE
Update Readme as LOB types are already supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This driver provides the following features:
 * Binary data transfer
 * Execution of prepared statements with bindings
 * Execution of batch statements without bindings
-* Read and write support for all data types except LOB types (e.g. `BLOB`, `CLOB`)
+* Read and write support for all data types.
 * Fetching of `REFCURSOR` using `io.r2dbc.postgresql.api.RefCursor`
 * Extension points to register `Codec`s to handle additional PostgreSQL data types
 


### PR DESCRIPTION
As per chat discussion on https://gitter.im/R2DBC/r2dbc#, Mark Paluch @mp911de mentioned that support is already present, but readme is not updated

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
