### PR TITLE
Bump Netty to 4.1.89.Final, CVE-2022-41915

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <mbr.version>0.3.0.RELEASE</mbr.version>
         <logback.version>1.3.4</logback.version>
         <mockito.version>4.8.1</mockito.version>
-        <netty.version>4.1.85.Final</netty.version>
+        <netty.version>4.1.89.Final</netty.version>
         <postgresql.version>42.5.1</postgresql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
* The CVE is probably not related to how Netty is used in r2dbc-postgresql but nice to use latest patch to avoid warnings from security scanning tools.
