### PR TITLE
Handle early disconnects before SSL handshake

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/client/SSLSessionHandlerAdapter.java
+++ b/src/main/java/io/r2dbc/postgresql/client/SSLSessionHandlerAdapter.java
@@ -40,17 +40,17 @@ final class SSLSessionHandlerAdapter extends AbstractPostgresSSLHandlerAdapter {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) {
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
         Mono.from(SSLRequest.INSTANCE.encode(this.alloc)).subscribe(ctx::writeAndFlush);
-        ctx.fireChannelActive();
+        super.channelActive(ctx);
     }
 
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) {
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         // If we receive channel inactive before removing this handler, then the inbound has closed early.
         PostgresqlSslException e = new PostgresqlSslException("Connection closed during SSL negotiation");
         completeHandshakeExceptionally(e);
-        ctx.fireChannelInactive();
+        super.channelInactive(ctx);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/client/SSLTunnelHandlerAdapter.java
+++ b/src/main/java/io/r2dbc/postgresql/client/SSLTunnelHandlerAdapter.java
@@ -40,9 +40,7 @@ final class SSLTunnelHandlerAdapter extends AbstractPostgresSSLHandlerAdapter {
             completeHandshakeExceptionally(e);
             return;
         }
-        ctx.channel().pipeline()
-            .addFirst(this.getSslHandler())
-            .remove(this);
+        ctx.channel().pipeline().addFirst(this.getSslHandler());
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/client/DowntimeIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/DowntimeIntegrationTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.client;
+
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import org.junit.jupiter.api.Test;
+import reactor.netty.DisposableChannel;
+import reactor.netty.DisposableServer;
+import reactor.netty.tcp.TcpServer;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DowntimeIntegrationTests {
+
+    @Test
+    void failSslHandshakeIfInboundClosed() {
+        // Simulate server downtime, where connections are accepted and then closed immediately
+        DisposableServer server =
+            TcpServer.create()
+                .doOnConnection(DisposableChannel::dispose)
+                .bindNow();
+
+        PostgresqlConnectionFactory connectionFactory =
+            new PostgresqlConnectionFactory(
+                PostgresqlConnectionConfiguration.builder()
+                    .host(server.host())
+                    .port(server.port())
+                    .username("test")
+                    .sslMode(SSLMode.REQUIRE)
+                    .build());
+
+        connectionFactory.create()
+            .as(StepVerifier::create)
+            .verifyErrorSatisfies(error ->
+                assertThat(error)
+                    .isInstanceOf(AbstractPostgresSSLHandlerAdapter.PostgresqlSslException.class)
+                    .hasMessage("Connection closed during SSL negotiation"));
+
+        server.disposeNow();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/client/DowntimeIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/DowntimeIntegrationTests.java
@@ -18,41 +18,65 @@ package io.r2dbc.postgresql.client;
 
 import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
 import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.postgresql.api.PostgresqlException;
 import org.junit.jupiter.api.Test;
 import reactor.netty.DisposableChannel;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
 import reactor.test.StepVerifier;
 
+import java.nio.channels.ClosedChannelException;
+import java.util.function.Consumer;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DowntimeIntegrationTests {
 
+    // Simulate server downtime, where connections are accepted and then closed immediately
+    static DisposableServer newServer() {
+        return TcpServer.create()
+            .doOnConnection(DisposableChannel::dispose)
+            .bindNow();
+    }
+
+    static PostgresqlConnectionFactory newConnectionFactory(DisposableServer server, SSLMode sslMode) {
+        return new PostgresqlConnectionFactory(
+            PostgresqlConnectionConfiguration.builder()
+                .host(server.host())
+                .port(server.port())
+                .username("test")
+                .sslMode(sslMode)
+                .build());
+    }
+
+    static void verifyError(SSLMode sslMode, Consumer<Throwable> assertions) {
+        DisposableServer server = newServer();
+        PostgresqlConnectionFactory connectionFactory = newConnectionFactory(server, sslMode);
+        connectionFactory.create().as(StepVerifier::create).verifyErrorSatisfies(assertions);
+        server.disposeNow();
+    }
+
     @Test
     void failSslHandshakeIfInboundClosed() {
-        // Simulate server downtime, where connections are accepted and then closed immediately
-        DisposableServer server =
-            TcpServer.create()
-                .doOnConnection(DisposableChannel::dispose)
-                .bindNow();
+        verifyError(SSLMode.REQUIRE, error ->
+            assertThat(error)
+                .isInstanceOf(AbstractPostgresSSLHandlerAdapter.PostgresqlSslException.class)
+                .hasMessage("Connection closed during SSL negotiation"));
+    }
 
-        PostgresqlConnectionFactory connectionFactory =
-            new PostgresqlConnectionFactory(
-                PostgresqlConnectionConfiguration.builder()
-                    .host(server.host())
-                    .port(server.port())
-                    .username("test")
-                    .sslMode(SSLMode.REQUIRE)
-                    .build());
+    @Test
+    void failSslTunnelIfInboundClosed() {
+        verifyError(SSLMode.TUNNEL, error -> {
+            assertThat(error)
+                .isInstanceOf(PostgresqlException.class)
+                .cause()
+                .isInstanceOf(ClosedChannelException.class);
 
-        connectionFactory.create()
-            .as(StepVerifier::create)
-            .verifyErrorSatisfies(error ->
-                assertThat(error)
-                    .isInstanceOf(AbstractPostgresSSLHandlerAdapter.PostgresqlSslException.class)
-                    .hasMessage("Connection closed during SSL negotiation"));
+            assertThat(error.getCause().getSuppressed().length).isOne();
 
-        server.disposeNow();
+            assertThat(error.getCause().getSuppressed()[0])
+                .hasMessage("Connection closed while SSL/TLS handshake was in progress");
+        });
     }
 
 }


### PR DESCRIPTION
Refs #595

Handle the inbound connection closing before SSL negotiation and always complete the SSL handshake future.

At first, only added the channel inactive lifecycle event in `SSLSessionHandlerAdapter`. But with the channel pipeline being updated after connect, found that the inbound could already be closed before the handler was added (could check if it's active) but the channel could also be unregistered and outside the event loop and then the handler added event would be pending and never called. So reworked the pipeline changes so that the SSL adapter is added on channel init, so all lifecycle events are received. Pass the handshake Mono via a channel attribute — not sure if there's a better way, and the SSL adapter may already have swapped itself for the underlying SSL handler.

Simple integration test for checking that disconnects are completed exceptionally, simulating what we've seen with Google Cloud SQL. Before these changes, this test will hang. No test specifically for the races between the disconnects and the handler lifecycle events, but have tested these changes manually under load.