### PR TITLE
Add column name index mapping in `PostgresqlRow`

### DIFF
--- a/src/test/java/io/r2dbc/postgresql/PostgresqlRowUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlRowUnitTests.java
@@ -132,6 +132,7 @@ final class PostgresqlRowUnitTests {
             .build();
 
         assertThat(new PostgresqlRow(MockContext.builder().codecs(codecs).build(), new PostgresqlRowMetadata(Collections.emptyList()), this.columns, this.data).get("test-name-2", Object.class)).isSameAs(value);
+        assertThat(new PostgresqlRow(MockContext.builder().codecs(codecs).build(), new PostgresqlRowMetadata(Collections.emptyList()), this.columns, this.data).get("tEsT-nAme-2", Object.class)).isSameAs(value);
     }
 
     @Test


### PR DESCRIPTION
[resolves #636]

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [ x ] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [ x ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ x ] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ x ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->

Previously getting the fields of the row results requires looping the fields array list to find the field with the specified name, this can be very slow when there's a large amount of columns retrieved. Here I am trying to add a cache to map the column name to index such that we only need to loop the fields list once.
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
