### PR TITLE
Reuse column index mapping from `PostgresqlColumnMetadata`

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlRowMetadata.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlRowMetadata.java
@@ -26,9 +26,11 @@ import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -42,14 +44,19 @@ final class PostgresqlRowMetadata extends AbstractCollection<String> implements 
 
     private final Map<String, PostgresqlColumnMetadata> nameKeyedColumns;
 
+    private final Map<String, Integer> columnNameIndexMap;
+
     PostgresqlRowMetadata(List<PostgresqlColumnMetadata> columnMetadatas) {
         this.columnMetadatas = Assert.requireNonNull(columnMetadatas, "columnMetadatas must not be null");
         this.nameKeyedColumns = new LinkedHashMap<>();
+        this.columnNameIndexMap = new HashMap<>(columnMetadatas.size(), 1);
 
+        int i = 0;
         for (PostgresqlColumnMetadata columnMetadata : columnMetadatas) {
             if (!this.nameKeyedColumns.containsKey(columnMetadata.getName())) {
                 this.nameKeyedColumns.put(columnMetadata.getName(), columnMetadata);
             }
+            columnNameIndexMap.putIfAbsent(columnMetadata.getName().toLowerCase(Locale.ROOT), i++);
         }
     }
 
@@ -181,6 +188,10 @@ final class PostgresqlRowMetadata extends AbstractCollection<String> implements 
         }
 
         return column;
+    }
+
+    Map<String, Integer> getColumnNameIndexMap() {
+        return this.columnNameIndexMap;
     }
 
     static PostgresqlRowMetadata toRowMetadata(Codecs codecs, RowDescription rowDescription) {


### PR DESCRIPTION
[resolves #636]

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [ x ] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [ x ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ x ] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ x ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->

Following up on the previous change #640 , the field name look up is still not optimal for usecases where the result contains a large chunk of data. Take [r2dbc example usecase](https://r2dbc.io/),

```java
Mono.from(connectionFactory.create())
  .flatMapMany(connection -> connection
    .createStatement("SELECT firstname FROM PERSON WHERE age > $1")
    .bind("$1", 42)
    .execute())
  .flatMap(result -> result
    .map((row, rowMetadata) -> row.get("firstname", String.class)))
  .doOnNext(System.out::println)
  .subscribe();
```

imagine the result set returns 1 million rows of data, because currently the row level column name index map is computed on the fly per row, the same mapping would need to be computed 1 million times, which is pretty much futile work, as we only need to compute the mapping once. Meanwhile, looking at the implementation of pgjdbc, the mapping is computed per result set.

Another small change I made is to avoid putting caches on case matches, and defaults the match to lower case. Since metadata object now owns the column name lookup cache, and each row might be processed concurrently, the cache can have concurrency problem when multiple threads want to put cache simultaneously. So I am now making it read only.
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
