### PR TITLE
#653 SNIHostName is going to throw an exception when hostname has a traili…

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/client/SSLConfig.java
+++ b/src/main/java/io/r2dbc/postgresql/client/SSLConfig.java
@@ -108,9 +108,7 @@ public final class SSLConfig {
                 return false;
             }
         }
-        if (input.endsWith("."))
-            return false;
-        return true;
+        return !input.endsWith(".");
     }
 
     //

--- a/src/main/java/io/r2dbc/postgresql/client/SSLConfig.java
+++ b/src/main/java/io/r2dbc/postgresql/client/SSLConfig.java
@@ -108,6 +108,8 @@ public final class SSLConfig {
                 return false;
             }
         }
+        if (input.endsWith("."))
+            return false;
         return true;
     }
 

--- a/src/test/java/io/r2dbc/postgresql/client/SSLConfigTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/SSLConfigTests.java
@@ -1,0 +1,17 @@
+package io.r2dbc.postgresql.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SSLConfig}.
+ */
+final class SSLConfigTests {
+    @Test
+    public void testValidSniHostname(){
+        assertThat(SSLConfig.isValidSniHostname("example.com")).isEqualTo(true);
+        assertThat(SSLConfig.isValidSniHostname("example://.com")).isEqualTo(false);
+        assertThat(SSLConfig.isValidSniHostname("example.com.")).isEqualTo(false);
+    }
+}


### PR DESCRIPTION
…ng dot

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

SSL SNI hostname with trailing dot unable to connect
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

Minor issue, as there is an easy workaround to disable SNI through configuration that avoids the issue entirely. The underlying library throws an error when there is a trailing dot on an SNI hostname. Looks easy enough to match that library's validation in the SSLConfig validation.