### PR TITLE
Fix self-suppression when standby is unavailable

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/MultiHostConnectionStrategy.java
+++ b/src/main/java/io/r2dbc/postgresql/MultiHostConnectionStrategy.java
@@ -73,7 +73,7 @@ public final class MultiHostConnectionStrategy implements ConnectionStrategy {
 
     @Override
     public Mono<Client> connect() {
-        return connect(this.multiHostConfiguration.getTargetServerType());
+        return Mono.defer(() -> connect(this.multiHostConfiguration.getTargetServerType()));
     }
 
     @Override
@@ -85,7 +85,7 @@ public final class MultiHostConnectionStrategy implements ConnectionStrategy {
     public Mono<Client> connect(TargetServerType targetServerType) {
         AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
 
-        return attemptConnection(targetServerType)
+        return Mono.defer(() -> attemptConnection(targetServerType))
             .onErrorResume(e -> {
                 if (!exceptionRef.compareAndSet(null, e)) {
                     exceptionRef.get().addSuppressed(e);


### PR DESCRIPTION
This commit fixes self-suppression exception when using preferSecondary and all standby servers are unavailable
Fix for issue: https://github.com/pgjdbc/r2dbc-postgresql/issues/677

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

#### Issue description

Issue described in: https://github.com/pgjdbc/r2dbc-postgresql/issues/677
 
#### New Public APIs

NA

#### Additional context

NA
