### PR TITLE
Include `OID` explicitly in the `SELECT` clause for older Postgres databases

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/PostgresTypes.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/PostgresTypes.java
@@ -40,7 +40,7 @@ public class PostgresTypes {
     public final static int NO_SUCH_TYPE = -1;
 
     // parameterized with %s for the comparator (=, IN), %s for the actual criteria value and %s for a potential LIMIT 1 statement
-    private static final String SELECT_PG_TYPE = "SELECT pg_type.* "
+    private static final String SELECT_PG_TYPE = "SELECT pg_type.oid, pg_type.* "
         + "  FROM pg_catalog.pg_type "
         + "  LEFT "
         + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description
- This change addresses a compatibility issue with PostgreSQL 11.
- In PostgreSQL 11, the oid column is considered a system column and is not included by default in SELECT * queries. As a result, the query must explicitly specify the oid field to retrieve it. This change updates the query to ensure the oid is selected explicitly for proper behavior across PostgreSQL versions.

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs
None.
<!--- List any new public APIs added with this Fix. --->

#### Additional context
- No other functional changes were introduced.
<!-- Add any other context about the problem here. Do not add code as screenshots. -->
- Closes #670 
