### PR TITLE
Release ByteBuf on channel write failure in ReactorNettyClient

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -199,7 +199,21 @@ public final class ReactorNettyClient implements Client {
                 if (DEBUG_ENABLED) {
                     logger.debug(this.context.getMessage(String.format("Request:  %s", message)));
                 }
-                return connection.outbound().send(message.encode(this.byteBufAllocator));
+                return Flux.from(message.encode(this.byteBufAllocator))
+                    .flatMap(buf ->
+                        connection.outbound().send(Mono.just(buf)).then()
+                            .doOnError(e -> {
+                                if (buf.refCnt() > 0) {
+                                    ReferenceCountUtil.release(buf);
+                                }
+                            })
+                            .doOnCancel(() -> {
+                                if (buf.refCnt() > 0) {
+                                    ReferenceCountUtil.release(buf);
+                                }
+                            })
+                    )
+                    .then();
             }, 1)
             .then();
 
@@ -226,7 +240,23 @@ public final class ReactorNettyClient implements Client {
 
                 return Flux.just(Terminate.INSTANCE)
                     .doOnNext(message -> logger.debug(this.context.getMessage(String.format("Request:  %s", message))))
-                    .concatMap(message -> this.connection.outbound().send(message.encode(this.connection.outbound().alloc())))
+                    .concatMap(message ->
+                        Flux.from(message.encode(this.connection.outbound().alloc()))
+                            .flatMap(buf ->
+                                this.connection.outbound().send(Mono.just(buf)).then()
+                                    .doOnError(e -> {
+                                        if (buf.refCnt() > 0) {
+                                            ReferenceCountUtil.release(buf);
+                                        }
+                                    })
+                                    .doOnCancel(() -> {
+                                        if (buf.refCnt() > 0) {
+                                            ReferenceCountUtil.release(buf);
+                                        }
+                                    })
+                            )
+                            .then()
+                    )
                     .then()
                     .doOnSuccess(v -> this.connection.dispose())
                     .then(this.connection.onDispose());


### PR DESCRIPTION
## Problem

When a Netty channel write fails (broken connection, RST packet, connection refused), the `ByteBuf` produced by `FrontendMessage.encode()` is never released, causing a direct memory leak detectable by Netty's `ResourceLeakDetector`.

```
  io.netty.util.ResourceLeakDetector : LEAK: ByteBuf.release() was not called
    before it's garbage-collected.
    ...
    io.r2dbc.postgresql.message.frontend.Query.lambda$encode$0(Query.java:60)
    ...
    io.r2dbc.postgresql.client.ReactorNettyClient.doSendRequest(...)
```

## Root Cause

   All 21 `FrontendMessage.encode()` implementations use `Mono.fromSupplier()` with no cleanup hook. `ReactorNettyClient` subscribes to `encode()` and passes the resulting `ByteBuf` to `connection.outbound().send()`. When the channel write fails, reactor-netty does **not** release the ByteBuf —
  and neither does `ReactorNettyClient`.


## Fix

Separate encode from send: materialize the `ByteBuf` first via `Flux.from(encode())`, then write it with `doOnError` and `doOnCancel` hooks that release the buffer if the write fails or is cancelled.

   ```java
   return Flux.from(message.encode(this.byteBufAllocator))
       .flatMap(buf ->
           connection.outbound().send(Mono.just(buf)).then()
               .doOnError(e -> {
                   if (buf.refCnt() > 0) {
                       ReferenceCountUtil.release(buf);
                   }
               })
               .doOnCancel(() -> {
                   if (buf.refCnt() > 0) {
                       ReferenceCountUtil.release(buf);
                   }
               })
       )
       .then();
  ```

  The refCnt() > 0 check prevents double-release — on successful write, Netty's channel pipeline already releases the buffer.

  Fixed in both locations:

   - The request pipeline (constructor)
   - The close() method (Terminate message)

  Why consumer-side fix (not producer-side)

   - Fixing each of 21 encode() methods with Mono.using() would be fragile and repetitive
   - Mono.using() cleanup risks double-release since Netty releases on successful write
   - One fix in ReactorNettyClient covers all message types

##  Reproducer

  Full reproducer with deterministic proof (no Docker needed) and integration tests:
  https://github.com/bugs84/r2dbc-postgresql-bytebuf-leak-reproducer

## References

  Fixes #580
  Related: #393, #248

