### PR TITLE
Additionally support Postgis Geography codec under one generic PostgisCodec

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/BuiltinDynamicCodecs.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BuiltinDynamicCodecs.java
@@ -34,8 +34,6 @@ import java.util.stream.Collectors;
  */
 public class BuiltinDynamicCodecs implements CodecRegistrar {
 
-    private static final Object EMPTY = new Object();
-
     enum BuiltinCodec {
 
         HSTORE("hstore"),
@@ -47,7 +45,18 @@ public class BuiltinDynamicCodecs implements CodecRegistrar {
             public boolean isSupported() {
                 return this.jtsPresent;
             }
-        }, VECTOR("vector");
+        },
+        POSTGIS_GEOGRAPHY("geography") {
+
+            private final boolean jtsPresent = isPresent(BuiltinDynamicCodecs.class.getClassLoader(), "org.locationtech.jts.geom.Geometry");
+
+            @Override
+            public boolean isSupported() {
+                return this.jtsPresent;
+            }
+        },
+
+        VECTOR("vector");
 
         private final String name;
 
@@ -60,8 +69,6 @@ public class BuiltinDynamicCodecs implements CodecRegistrar {
             switch (this) {
                 case HSTORE:
                     return Collections.singletonList(new HStoreCodec(byteBufAllocator, oid));
-                case POSTGIS_GEOMETRY:
-                    return Collections.singletonList(new PostgisGeometryCodec(oid));
                 case VECTOR:
                     VectorCodec vectorCodec = new VectorCodec(byteBufAllocator, oid, typarray);
                     List<Codec<?>> codecs = new ArrayList<>(3);
@@ -105,17 +112,62 @@ public class BuiltinDynamicCodecs implements CodecRegistrar {
             .flatMap(it -> it.map((row, rowMetadata) -> {
 
                     String typname = row.get("typname", String.class);
-
                     BuiltinCodec lookup = BuiltinCodec.lookup(typname);
-                    if (lookup.isSupported()) {
-                        int oid = PostgresqlObjectId.toInt(row.get("oid", Long.class));
-                        int typarray = rowMetadata.contains("typarray") ? PostgresqlObjectId.toInt(row.get("typarray", Long.class)) : PostgresTypes.NO_SUCH_TYPE;
-                        lookup.createCodec(byteBufAllocator, oid, typarray).forEach(registry::addLast);
-                    }
+                    int oid = PostgresqlObjectId.toInt(row.get("oid", Long.class));
+                    int typarray = rowMetadata.contains("typarray") ? PostgresqlObjectId.toInt(row.get("typarray", Long.class)) : PostgresTypes.NO_SUCH_TYPE;
 
-                    return EMPTY;
+                    return new DiscoveredType(lookup, oid, typarray);
                 })
-            ).then();
+            )
+            .collectList()
+            .doOnNext(types -> registerCodecs(types, byteBufAllocator, registry))
+            .then();
+    }
+
+    void registerCodecs(List<DiscoveredType> types, ByteBufAllocator byteBufAllocator, CodecRegistry registry) {
+
+        int geometryOid = PostgresTypes.NO_SUCH_TYPE;
+        int geographyOid = PostgresTypes.NO_SUCH_TYPE;
+
+        for (DiscoveredType discovered : types) {
+
+            if (!discovered.codec.isSupported()) {
+                continue;
+            }
+
+            switch (discovered.codec) {
+                case POSTGIS_GEOMETRY:
+                    geometryOid = discovered.oid;
+                    continue;
+                case POSTGIS_GEOGRAPHY:
+                    geographyOid = discovered.oid;
+                    continue;
+                default:
+                    discovered.codec.createCodec(byteBufAllocator, discovered.oid, discovered.typarray).forEach(registry::addLast);
+            }
+        }
+
+        // geometry and geography share a single codec so that a plain JTS Geometry is unambiguous for encoding; Postgres applies its own
+        // geometry -> geography implicit cast wherever a geography value is actually required.
+        if (geometryOid != PostgresTypes.NO_SUCH_TYPE) {
+            registry.addLast(new PostgisCodec(geometryOid, geographyOid));
+        }
+    }
+
+    static final class DiscoveredType {
+
+        private final BuiltinCodec codec;
+
+        private final int oid;
+
+        private final int typarray;
+
+        DiscoveredType(BuiltinCodec codec, int oid, int typarray) {
+            this.codec = codec;
+            this.oid = oid;
+            this.typarray = typarray;
+        }
+
     }
 
     private PostgresqlStatement createQuery(PostgresqlConnection connection) {

--- a/src/main/java/io/r2dbc/postgresql/codec/PostgisCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/PostgisCodec.java
@@ -31,28 +31,39 @@ import org.locationtech.jts.io.WKBWriter;
 import org.locationtech.jts.io.WKTWriter;
 import reactor.core.publisher.Mono;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static io.r2dbc.postgresql.client.EncodedParameter.NULL_VALUE;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 
 /**
- * PostGIS codec using {@link WKBReader} and {@link WKTWriter}.
+ * PostGIS codec using {@link WKBReader} and {@link WKTWriter}, shared between the {@code geometry} and {@code geography} Postgres types.
+ * <p>Both types decode to and encode from the same JTS {@link Geometry} representation, so a single codec instance handles both, the same way {@link StringCodec} handles {@code text} and
+ * {@code varchar} alike. Values encoded without an explicit target type default to the {@code geometry} OID; Postgres applies its own {@code geometry -> geography} implicit cast where a
+ * {@code geography} value is actually required.
  */
-final class PostgisGeometryCodec implements Codec<Geometry>, CodecMetadata {
+final class PostgisCodec implements Codec<Geometry>, CodecMetadata {
 
     private static final Class<Geometry> TYPE = Geometry.class;
 
     private final GeometryFactory geometryFactory = new GeometryFactory();
 
-    private final int oid;
+    private final int geometryOid;
+
+    private final int geographyOid;
 
     /**
-     * Create a new {@link PostgisGeometryCodec}.
+     * Create a new {@link PostgisCodec}.
+     *
+     * @param geometryOid  the OID of the {@code geometry} type, used as the default encoding target
+     * @param geographyOid the OID of the {@code geography} type, or {@link PostgresTypes#NO_SUCH_TYPE} if not present
      */
-    PostgisGeometryCodec(int oid) {
-        this.oid = oid;
+    PostgisCodec(int geometryOid, int geographyOid) {
+        this.geometryOid = geometryOid;
+        this.geographyOid = geographyOid;
     }
 
     @Override
@@ -61,7 +72,7 @@ final class PostgisGeometryCodec implements Codec<Geometry>, CodecMetadata {
         Assert.requireNonNull(type, "type must not be null");
 
         // Object = Geometry or Geometry = type (Geometry subtype)
-        return dataType == this.oid && (type.isAssignableFrom(TYPE) || TYPE.isAssignableFrom(type));
+        return (dataType == this.geometryOid || dataType == this.geographyOid) && (type.isAssignableFrom(TYPE) || TYPE.isAssignableFrom(type));
     }
 
     @Override
@@ -95,24 +106,24 @@ final class PostgisGeometryCodec implements Codec<Geometry>, CodecMetadata {
 
     @Override
     public EncodedParameter encode(Object value) {
+        return encode(value, this.geometryOid);
+    }
+
+    @Override
+    public EncodedParameter encode(Object value, int dataType) {
         Assert.requireType(value, Geometry.class, "value must be Geometry type");
         Geometry geometry = (Geometry) value;
 
         WKBWriter writer = new WKBWriter(2, true);
 
-        return new EncodedParameter(FORMAT_BINARY, this.oid, Mono.fromSupplier(
+        return new EncodedParameter(FORMAT_BINARY, dataType, Mono.fromSupplier(
             () -> Unpooled.wrappedBuffer(writer.write(geometry))
         ));
     }
 
     @Override
-    public EncodedParameter encode(Object value, int dataType) {
-        return encode(value);
-    }
-
-    @Override
     public EncodedParameter encodeNull() {
-        return new EncodedParameter(FORMAT_BINARY, this.oid, NULL_VALUE);
+        return new EncodedParameter(FORMAT_BINARY, this.geometryOid, NULL_VALUE);
     }
 
     @Override
@@ -122,7 +133,14 @@ final class PostgisGeometryCodec implements Codec<Geometry>, CodecMetadata {
 
     @Override
     public Iterable<PostgresTypeIdentifier> getDataTypes() {
-        return Collections.singleton(AbstractCodec.getDataType(this.oid));
+        List<PostgresTypeIdentifier> dataTypes = new ArrayList<>(2);
+        dataTypes.add(AbstractCodec.getDataType(this.geometryOid));
+
+        if (this.geographyOid != PostgresTypes.NO_SUCH_TYPE) {
+            dataTypes.add(AbstractCodec.getDataType(this.geographyOid));
+        }
+
+        return Collections.unmodifiableList(dataTypes);
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/PostgisIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgisIntegrationTests.java
@@ -18,9 +18,11 @@ package io.r2dbc.postgresql;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -81,6 +83,49 @@ final class PostgisIntegrationTests extends AbstractIntegrationTests {
             assertThat(actual).isEqualTo(point);
             assertThat(((Point) actual).getSRID()).isEqualTo(point.getSRID());
         }).verifyComplete();
+    }
+
+    @Test
+    void shouldWriteGeometryValueIntoGeographyColumnViaImplicitCast() {
+
+        JdbcOperations jdbcOperations = SERVER.getJdbcOperations();
+
+        jdbcOperations.execute("DROP TABLE IF EXISTS geo_test_geography");
+        jdbcOperations.execute("CREATE TABLE geo_test_geography (geog geography(Point, 4326))");
+
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        Point point = geometryFactory.createPoint(new Coordinate(-73.985428, 40.748817));
+
+        // No explicit target OID is bound here, so the driver encodes this plain Geometry with the `geometry` OID (its default).
+        // Postgres must apply its own `geometry -> geography` cast to accept it into this geography-typed column.
+        this.connection.createStatement("INSERT INTO geo_test_geography VALUES($1)").bind("$1", point).execute().flatMap(it -> it.getRowsUpdated()).then().as(StepVerifier::create).verifyComplete();
+
+        this.connection.createStatement("SELECT * FROM geo_test_geography").execute().flatMap(it -> it.map(row -> row.get("geog"))).as(StepVerifier::create).consumeNextWith(actual -> {
+            assertThat(actual).isEqualTo(point);
+        }).verifyComplete();
+    }
+
+    @Test
+    void shouldResolveWhereClauseOperatorAgainstGeographyColumn() {
+
+        JdbcOperations jdbcOperations = SERVER.getJdbcOperations();
+
+        jdbcOperations.execute("DROP TABLE IF EXISTS geo_test_geography_where");
+        jdbcOperations.execute("CREATE TABLE geo_test_geography_where (geog geography(Point, 4326))");
+
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        Point point = geometryFactory.createPoint(new Coordinate(-73.985428, 40.748817));
+
+        jdbcOperations.update("INSERT INTO geo_test_geography_where VALUES(ST_GeogFromText(?))", String.format("SRID=4326;POINT(%s %s)", point.getX(), point.getY()));
+
+        // Resolving `geog = $1` where $1 is bound as a plain (geometry-OID-tagged) Geometry only works without an explicit
+        // `::geography` cast in the SQL if Postgres treats `geometry -> geography` as an IMPLICIT cast. An ASSIGNMENT-only
+        // cast would fail here with "operator does not exist: geography = geometry".
+        this.connection.createStatement("SELECT * FROM geo_test_geography_where WHERE geog = $1").bind("$1", point).execute()
+            .flatMap(it -> it.map(row -> row.get("geog")))
+            .as(StepVerifier::create)
+            .consumeNextWith(actual -> assertThat(actual).isEqualTo(point))
+            .verifyComplete();
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/codec/BuiltinDynamicCodecsUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/BuiltinDynamicCodecsUnitTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.client.ParameterAssert;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.r2dbc.postgresql.codec.BuiltinDynamicCodecs.BuiltinCodec.POSTGIS_GEOGRAPHY;
+import static io.r2dbc.postgresql.codec.BuiltinDynamicCodecs.BuiltinCodec.POSTGIS_GEOMETRY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link BuiltinDynamicCodecs}, in particular the pairing of the {@code geometry} and {@code geography} OIDs into a single {@link PostgisCodec}.
+ */
+final class BuiltinDynamicCodecsUnitTests {
+
+    private static final int GEOMETRY_OID = 111111;
+
+    private static final int GEOGRAPHY_OID = 222222;
+
+    private final BuiltinDynamicCodecs codecs = new BuiltinDynamicCodecs();
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Test
+    void registersSinglePostgisCodecForGeometryAndGeography() {
+
+        List<BuiltinDynamicCodecs.DiscoveredType> discovered = Arrays.asList(
+            new BuiltinDynamicCodecs.DiscoveredType(POSTGIS_GEOMETRY, GEOMETRY_OID, PostgresTypes.NO_SUCH_TYPE),
+            new BuiltinDynamicCodecs.DiscoveredType(POSTGIS_GEOGRAPHY, GEOGRAPHY_OID, PostgresTypes.NO_SUCH_TYPE)
+        );
+
+        DefaultCodecs registry = new DefaultCodecs(TEST);
+        this.codecs.registerCodecs(discovered, TEST, registry);
+
+        List<PostgisCodec> postgisCodecs = findPostgisCodecs(registry);
+        assertThat(postgisCodecs).hasSize(1);
+
+        PostgisCodec codec = postgisCodecs.get(0);
+        assertThat(codec.canDecode(GEOMETRY_OID, FORMAT_TEXT, Geometry.class)).isTrue();
+        assertThat(codec.canDecode(GEOGRAPHY_OID, FORMAT_TEXT, Geometry.class)).isTrue();
+
+        ParameterAssert.assertThat(codec.encode(this.geometryFactory.createPoint())).hasType(GEOMETRY_OID);
+    }
+
+    @Test
+    void registersPostgisCodecForGeometryOnlyWhenGeographyMissing() {
+
+        List<BuiltinDynamicCodecs.DiscoveredType> discovered = Collections.singletonList(
+            new BuiltinDynamicCodecs.DiscoveredType(POSTGIS_GEOMETRY, GEOMETRY_OID, PostgresTypes.NO_SUCH_TYPE)
+        );
+
+        DefaultCodecs registry = new DefaultCodecs(TEST);
+        this.codecs.registerCodecs(discovered, TEST, registry);
+
+        List<PostgisCodec> postgisCodecs = findPostgisCodecs(registry);
+        assertThat(postgisCodecs).hasSize(1);
+
+        PostgisCodec codec = postgisCodecs.get(0);
+        assertThat(codec.canDecode(GEOMETRY_OID, FORMAT_TEXT, Geometry.class)).isTrue();
+        assertThat(codec.canDecode(GEOGRAPHY_OID, FORMAT_TEXT, Geometry.class)).isFalse();
+    }
+
+    @Test
+    void registersNoPostgisCodecWhenGeometryMissing() {
+
+        List<BuiltinDynamicCodecs.DiscoveredType> discovered = Collections.singletonList(
+            new BuiltinDynamicCodecs.DiscoveredType(POSTGIS_GEOGRAPHY, GEOGRAPHY_OID, PostgresTypes.NO_SUCH_TYPE)
+        );
+
+        DefaultCodecs registry = new DefaultCodecs(TEST);
+        this.codecs.registerCodecs(discovered, TEST, registry);
+
+        assertThat(findPostgisCodecs(registry)).isEmpty();
+    }
+
+    private static List<PostgisCodec> findPostgisCodecs(DefaultCodecs registry) {
+
+        List<PostgisCodec> result = new ArrayList<>();
+        for (Codec<?> codec : registry) {
+            if (codec instanceof PostgisCodec) {
+                result.add((PostgisCodec) codec);
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/PostgisCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/PostgisCodecUnitTests.java
@@ -47,15 +47,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
- * Unit tests for {@link PostgisGeometryCodec}.
+ * Unit tests for {@link PostgisCodec}.
  */
-final class PostgisGeometryCodecUnitTests {
+final class PostgisCodecUnitTests {
 
     private static final int WGS84_SRID = 4326;
 
-    private static final int dataType = 23456;
+    private static final int geometryOid = 23456;
 
-    private final PostgisGeometryCodec codec = new PostgisGeometryCodec(dataType);
+    private static final int geographyOid = 23457;
+
+    private final PostgisCodec codec = new PostgisCodec(geometryOid, geographyOid);
 
     private final WKBWriter wkbWriter = new WKBWriter();
 
@@ -65,33 +67,43 @@ final class PostgisGeometryCodecUnitTests {
 
     @Test
     void canDecodeNoFormat() {
-        assertThatIllegalArgumentException().isThrownBy(() -> this.codec.canDecode(dataType, null, Geometry.class))
+        assertThatIllegalArgumentException().isThrownBy(() -> this.codec.canDecode(geometryOid, null, Geometry.class))
             .withMessage("format must not be null");
     }
 
     @Test
     void canDecodeNoClass() {
-        assertThatIllegalArgumentException().isThrownBy(() -> this.codec.canDecode(dataType, FORMAT_TEXT, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> this.codec.canDecode(geometryOid, FORMAT_TEXT, null))
             .withMessage("type must not be null");
     }
 
     @Test
-    void canDecode() {
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, Geometry.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_BINARY, Geometry.class)).isTrue();
+    void canDecodeGeometryAndGeography() {
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, Geometry.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_BINARY, Geometry.class)).isTrue();
+        assertThat(this.codec.canDecode(geographyOid, FORMAT_TEXT, Geometry.class)).isTrue();
+        assertThat(this.codec.canDecode(geographyOid, FORMAT_BINARY, Geometry.class)).isTrue();
 
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, Point.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, MultiPoint.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, LineString.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, LinearRing.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, MultiLineString.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, Polygon.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, MultiPolygon.class)).isTrue();
-        assertThat(this.codec.canDecode(dataType, FORMAT_TEXT, GeometryCollection.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, Point.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, MultiPoint.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, LineString.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, LinearRing.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, MultiLineString.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, Polygon.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, MultiPolygon.class)).isTrue();
+        assertThat(this.codec.canDecode(geometryOid, FORMAT_TEXT, GeometryCollection.class)).isTrue();
 
         assertThat(this.codec.canDecode(VARCHAR.getObjectId(), FORMAT_BINARY, Geometry.class)).isFalse();
         assertThat(this.codec.canDecode(JSON.getObjectId(), FORMAT_TEXT, Geometry.class)).isFalse();
         assertThat(this.codec.canDecode(JSONB.getObjectId(), FORMAT_BINARY, Geometry.class)).isFalse();
+    }
+
+    @Test
+    void canDecodeGeographyAbsent() {
+        PostgisCodec noGeography = new PostgisCodec(geometryOid, PostgresTypes.NO_SUCH_TYPE);
+
+        assertThat(noGeography.canDecode(geometryOid, FORMAT_TEXT, Geometry.class)).isTrue();
+        assertThat(noGeography.canDecode(geographyOid, FORMAT_TEXT, Geometry.class)).isFalse();
     }
 
     @Test
@@ -117,26 +129,45 @@ final class PostgisGeometryCodecUnitTests {
 
     @Test
     @SuppressWarnings("unchecked")
-    void decode() {
+    void decodeFromGeometryOid() {
         byte[] pointBytes = this.wkbWriter.write(this.point);
         ByteBuf pointByteBuf = ByteBufUtils.encode(TEST, WKBWriter.toHex(pointBytes));
 
-        assertThat(this.codec.decode(pointByteBuf, dataType, FORMAT_TEXT, Geometry.class)).isEqualTo(this.point);
+        assertThat(this.codec.decode(pointByteBuf, geometryOid, FORMAT_TEXT, Geometry.class)).isEqualTo(this.point);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void decodeFromGeographyOid() {
+        byte[] pointBytes = this.wkbWriter.write(this.point);
+        ByteBuf pointByteBuf = ByteBufUtils.encode(TEST, WKBWriter.toHex(pointBytes));
+
+        assertThat(this.codec.decode(pointByteBuf, geographyOid, FORMAT_TEXT, Geometry.class)).isEqualTo(this.point);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void decodeNoByteBuf() {
-        assertThat(this.codec.decode(null, dataType, FORMAT_TEXT, Geometry.class)).isNull();
+        assertThat(this.codec.decode(null, geometryOid, FORMAT_TEXT, Geometry.class)).isNull();
     }
 
     @Test
-    void encode() {
+    void encodeDefaultsToGeometryOid() {
         ByteBuf encoded = Unpooled.wrappedBuffer(new WKBWriter(2, true).write(this.point));
 
         ParameterAssert.assertThat(this.codec.encode(this.point))
             .hasFormat(FORMAT_BINARY)
-            .hasType(dataType)
+            .hasType(geometryOid)
+            .hasValue(encoded);
+    }
+
+    @Test
+    void encodeWithExplicitGeographyOid() {
+        ByteBuf encoded = Unpooled.wrappedBuffer(new WKBWriter(2, true).write(this.point));
+
+        ParameterAssert.assertThat(this.codec.encode(this.point, geographyOid))
+            .hasFormat(FORMAT_BINARY)
+            .hasType(geographyOid)
             .hasValue(encoded);
     }
 
@@ -147,9 +178,9 @@ final class PostgisGeometryCodecUnitTests {
     }
 
     @Test
-    void encodeNull() {
-        assertThat(new PostgisGeometryCodec(dataType).encodeNull())
-            .isEqualTo(new EncodedParameter(FORMAT_BINARY, dataType, NULL_VALUE));
+    void encodeNullUsesGeometryOid() {
+        assertThat(this.codec.encodeNull())
+            .isEqualTo(new EncodedParameter(FORMAT_BINARY, geometryOid, NULL_VALUE));
     }
 
 }


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/pgjdbc/r2dbc-postgresql/blob/main/.github/CONTRIBUTING.adoc).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/pgjdbc/r2dbc-postgresql/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Resolves: https://github.com/pgjdbc/r2dbc-postgresql/issues/528

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

`PostgisGeographyCodec` (if this counts as an API).

#### Additional context

Note that the implementation does have a fair bit of boilerplate due to `PostgisGeographyCodec` being final and hence not being able to be subclassed. One alternative would be to have a package private implementation that both `PostgisGeographyCodec` and `PostgisGeometryCodec` can share (that way both `PostgisGeographyCodec` and `PostgisGeometryCodec` can be final).

As suggested in the linked github issue, the implementation is just a copy paste of `PostgisGeometryCodec` that also uses the `org.locationtech.jts.geom.Geometry` but this allows you to decode postgres `geography` types.